### PR TITLE
fix: Fix bugs when testing with bitcoind regtest

### DIFF
--- a/contrib/images/monitor/wrapper.sh
+++ b/contrib/images/monitor/wrapper.sh
@@ -15,7 +15,7 @@ export BABYLONGENESIS="/babylon/config/genesis.json"
 export VIGILANTECONFIG="/vigilante/${CONFIG}"
 export MONITORLOG="/vigilante/${LOG}"
 
-if [ -d "$(dirname "${REPORTERLOG}")" ]; then
+if [ -d "$(dirname "${MONITORLOG}")" ]; then
   "${BINARY}" monitor --config "${VIGILANTECONFIG}" --genesis "${BABYLONGENESIS}" 2>&1 | tee  "${REPORTERLOG}"
 else
   "${BINARY}" monitor --config "${VIGILANTECONFIG}" --genesis "${BABYLONGENESIS}" 2>&1

--- a/netparams/babylon.go
+++ b/netparams/babylon.go
@@ -28,6 +28,12 @@ func GetBabylonParams(net string, tagIdx uint8) *BabylonParams {
 			Tag:     btctxformatter.TestTag(tagIdx),
 			Version: btctxformatter.CurrentVersion,
 		}
+	case types.BtcRegtest.String():
+		// bitcoind uses regtest instead of simnet
+		return &BabylonParams{
+			Tag:     btctxformatter.TestTag(tagIdx),
+			Version: btctxformatter.CurrentVersion,
+		}
 	}
 
 	return nil

--- a/sample-vigilante-docker.yml
+++ b/sample-vigilante-docker.yml
@@ -1,27 +1,29 @@
 common:
-  retry-sleep-time: 5s
-  max-retry-sleep-time: 5m
+  retry-sleep-time: 1s
+  max-retry-sleep-time: 1m
 btc:
-  no-client-tls: false
-  ca-file: /bitcoin/rpc.cert
-  endpoint: host.docker.internal:18556
+  no-client-tls: true   # use true for bitcoind as it does not support tls
+  ca-file: ~
+  endpoint: bitcoindsim:18443  # use port 18443 for bitcoind regtest
   tx-fee-min: 1000
   tx-fee-max: 100000
   target-block-num: 2
-  wallet-endpoint: host.docker.internal:18554
+  wallet-endpoint: ~
   wallet-password: walletpass
   wallet-name: default
   wallet-lock-time: 10
-  wallet-ca-file: /bitcoin/rpc-wallet.cert
-  net-params: simnet
+  wallet-ca-file: ~
+  net-params: regtest # use regtest for bitcoind as it does not support simnet
   username: rpcuser
   password: rpcpass
   reconnect-attempts: 3
+  btc-backend: bitcoind # {btcd, bitcoind}
+  zmq-endpoint: tcp://bitcoindsim:29000 # use tcp://127.0.0.1:29000 if subscription-mode is zmq
 babylon:
   key: node0
   chain-id: chain-test
-  rpc-addr: http://host.docker.internal:26657
-  grpc-addr: https://host.docker.internal:9090
+  rpc-addr: http://babylondnode0:26657
+  grpc-addr: https://babylondnode0:9090
   account-prefix: bbn
   keyring-backend: test
   gas-adjustment: 1.2
@@ -37,16 +39,16 @@ babylon:
 grpc:
   onetime-tls-key: true
   rpc-key: ""
-  rpc-cert: "/vigilante/rpc.cert"
+  rpc-cert: /vigilante/rpc.cert
   endpoints:
     - localhost:8080
 grpcweb:
   placeholder: grpcwebconfig
 submitter:
   netparams: simnet
-  buffer-size: 10
+  buffer-size: 100
   polling-interval-seconds: 60
-  resend-interval-seconds: 60
+  resend-interval-seconds: 1800
 reporter:
   netparams: simnet
 monitor:


### PR DESCRIPTION
The bug is caused due to the fact that `bitcoind` uses `regtest` instead of `simnet`. So this PR added a handler for `regtest` net param. This PR also updates the configuration for docker which is mostly adapted from the [`babylon-deployment` repo](https://github.com/babylonchain/babylon-deployment/blob/main/vigilante-bitcoind.yml).