### PR TITLE
fix: pprof support and reduce mem usage of reporter

### DIFF
--- a/cmd/reporter/reporter.go
+++ b/cmd/reporter/reporter.go
@@ -2,7 +2,6 @@ package reporter
 
 import (
 	"fmt"
-	"net/http"
 	_ "net/http/pprof"
 
 	bbnclient "github.com/babylonchain/rpc-client/client"
@@ -93,10 +92,6 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 	// start Prometheus metrics server
 	addr := fmt.Sprintf("%s:%d", cfg.Metrics.Host, cfg.Metrics.ServerPort)
 	metrics.Start(addr)
-
-	go func() {
-		log.Println(http.ListenAndServe("localhost:10000", nil))
-	}()
 
 	// SIGINT handling stuff
 	utils.AddInterruptHandler(func() {

--- a/cmd/reporter/reporter.go
+++ b/cmd/reporter/reporter.go
@@ -2,6 +2,9 @@ package reporter
 
 import (
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+
 	bbnclient "github.com/babylonchain/rpc-client/client"
 	"github.com/babylonchain/vigilante/btcclient"
 	"github.com/babylonchain/vigilante/cmd/utils"
@@ -90,6 +93,10 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 	// start Prometheus metrics server
 	addr := fmt.Sprintf("%s:%d", cfg.Metrics.Host, cfg.Metrics.ServerPort)
 	metrics.Start(addr)
+
+	go func() {
+		log.Println(http.ListenAndServe("localhost:10000", nil))
+	}()
 
 	// SIGINT handling stuff
 	utils.AddInterruptHandler(func() {

--- a/cmd/reporter/reporter.go
+++ b/cmd/reporter/reporter.go
@@ -2,7 +2,6 @@ package reporter
 
 import (
 	"fmt"
-	_ "net/http/pprof"
 
 	bbnclient "github.com/babylonchain/rpc-client/client"
 	"github.com/babylonchain/vigilante/btcclient"

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"

--- a/reporter/bootstrapping.go
+++ b/reporter/bootstrapping.go
@@ -115,7 +115,7 @@ func (r *Reporter) initBTCCache() error {
 		ibs                  []*types.IndexedBlock
 	)
 
-	r.btcCache, err = types.NewBTCCache(10000) // TODO: give an option to be unsized
+	r.btcCache, err = types.NewBTCCache(1000) // TODO: give an option to be unsized
 	if err != nil {
 		return err
 	}

--- a/types/btccache.go
+++ b/types/btccache.go
@@ -190,6 +190,9 @@ func (b *BTCCache) FindBlock(blockHeight uint64) *IndexedBlock {
 }
 
 func (b *BTCCache) Resize(maxEntries uint64) error {
+	b.Lock()
+	defer b.Unlock()
+
 	if maxEntries == 0 {
 		return ErrInvalidMaxEntries
 	}


### PR DESCRIPTION
This PR adds pprof support for vigilantes, and applies some modifications for reducing the mem usage of reporter. In addition, it fixes a concurrency bug in BTC cache, which does not lead to any bug at the moment though.

After this PR, one can use `go tool pprof http://<reporter-ip>:2112/debug/pprof/heap` to get the heap dump, where `2112` is the existing Prometheus server of vigilante.