### PR TITLE
fix: Monitor/Fix out-of-memory bug when the bootstrapping is far behind

### DIFF
--- a/btcclient/interface.go
+++ b/btcclient/interface.go
@@ -1,12 +1,13 @@
 package btcclient
 
 import (
-	"github.com/babylonchain/vigilante/types"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+
+	"github.com/babylonchain/vigilante/types"
 )
 
 type BTCClient interface {
@@ -17,6 +18,7 @@ type BTCClient interface {
 	GetBestBlock() (*chainhash.Hash, uint64, error)
 	GetBlockByHash(blockHash *chainhash.Hash) (*types.IndexedBlock, *wire.MsgBlock, error)
 	FindTailBlocksByHeight(height uint64) ([]*types.IndexedBlock, error)
+	GetBlockByHeight(height uint64) (*types.IndexedBlock, *wire.MsgBlock, error)
 }
 
 type BTCWallet interface {

--- a/btcclient/query.go
+++ b/btcclient/query.go
@@ -40,8 +40,6 @@ func (c *Client) GetBlockByHash(blockHash *chainhash.Hash) (*types.IndexedBlock,
 }
 
 // GetBlockByHeight returns a block with the given height
-// and error would be returned if the block's parent block hash does not
-// match with parentHash
 func (c *Client) GetBlockByHeight(height uint64) (*types.IndexedBlock, *wire.MsgBlock, error) {
 	blockHash, err := c.GetBlockHash(int64(height))
 	if err != nil {

--- a/btcclient/query.go
+++ b/btcclient/query.go
@@ -2,9 +2,11 @@ package btcclient
 
 import (
 	"fmt"
-	"github.com/babylonchain/vigilante/types"
+
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
+
+	"github.com/babylonchain/vigilante/types"
 )
 
 // GetBestBlock provides similar functionality with the btcd.rpcclient.GetBestBlock function
@@ -25,16 +27,28 @@ func (c *Client) GetBestBlock() (*chainhash.Hash, uint64, error) {
 func (c *Client) GetBlockByHash(blockHash *chainhash.Hash) (*types.IndexedBlock, *wire.MsgBlock, error) {
 	blockInfo, err := c.GetBlockVerbose(blockHash)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get block verbose by hash %s: %w", blockHash.String(), err)
 	}
 
 	mBlock, err := c.GetBlock(blockHash)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to get block by hash %s: %w", blockHash.String(), err)
 	}
 
 	btcTxs := types.GetWrappedTxs(mBlock)
 	return types.NewIndexedBlock(int32(blockInfo.Height), &mBlock.Header, btcTxs), mBlock, nil
+}
+
+// GetBlockByHeight returns a block with the given height
+// and error would be returned if the block's parent block hash does not
+// match with parentHash
+func (c *Client) GetBlockByHeight(height uint64) (*types.IndexedBlock, *wire.MsgBlock, error) {
+	blockHash, err := c.GetBlockHash(int64(height))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get block by height %d: %w", height, err)
+	}
+
+	return c.GetBlockByHash(blockHash)
 }
 
 // getChainBlocks returns a chain of indexed blocks from the block at baseHeight to the tipBlock

--- a/monitor/btcscanner/btc_scanner.go
+++ b/monitor/btcscanner/btc_scanner.go
@@ -139,7 +139,7 @@ func (bs *BtcScanner) Bootstrap() {
 
 	_, bestHeight, err := bs.BtcClient.GetBestBlock()
 	if err != nil {
-		panic(fmt.Errorf("can not get the best BTC block"))
+		panic(fmt.Errorf("cannot get the best BTC block"))
 	}
 	for ; firstUnconfirmedHeight <= bestHeight; firstUnconfirmedHeight++ {
 		ib, _, err := bs.BtcClient.GetBlockByHeight(firstUnconfirmedHeight)

--- a/monitor/btcscanner/btc_scanner.go
+++ b/monitor/btcscanner/btc_scanner.go
@@ -116,7 +116,6 @@ func (bs *BtcScanner) Start() {
 func (bs *BtcScanner) Bootstrap() {
 	var (
 		firstUnconfirmedHeight uint64
-		chainBlocks            []*types.IndexedBlock
 		confirmedBlocks        []*types.IndexedBlock
 		err                    error
 	)
@@ -152,8 +151,7 @@ func (bs *BtcScanner) Bootstrap() {
 
 		confirmedBlocks = bs.UnconfirmedBlockCache.TrimConfirmedBlocks(int(bs.K))
 		if confirmedBlocks == nil {
-			log.Debug("bootstrapping is finished but no confirmed blocks are found")
-			return
+			continue
 		}
 
 		// if the scanner was bootstrapped before, the new confirmed canonical chain must connect to the previous one
@@ -166,7 +164,8 @@ func (bs *BtcScanner) Bootstrap() {
 
 		bs.sendConfirmedBlocksToChan(confirmedBlocks)
 	}
-	log.Infof("bootstrapping is finished at the tip confirmed height: %d and tip unconfirmed height: %d", bs.confirmedTipBlock.Height, chainBlocks[len(chainBlocks)-1].Height)
+	log.Infof("bootstrapping is finished at the tip confirmed height: %d",
+		bs.confirmedTipBlock.Height)
 }
 
 func (bs *BtcScanner) GetHeadersChan() chan *wire.BlockHeader {

--- a/monitor/btcscanner/btc_scanner_test.go
+++ b/monitor/btcscanner/btc_scanner_test.go
@@ -1,16 +1,18 @@
 package btcscanner_test
 
 import (
+	"math/rand"
+	"testing"
+
 	"github.com/babylonchain/babylon/testutil/datagen"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+
 	"github.com/babylonchain/vigilante/monitor/btcscanner"
 	vdatagen "github.com/babylonchain/vigilante/testutil/datagen"
 	"github.com/babylonchain/vigilante/testutil/mocks"
 	"github.com/babylonchain/vigilante/types"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
-	"math/rand"
-	"testing"
 )
 
 func FuzzBootStrap(f *testing.F) {
@@ -22,19 +24,23 @@ func FuzzBootStrap(f *testing.F) {
 		// Generate a random number of blocks
 		numBlocks := datagen.RandomIntOtherThan(0, 100) + k // make sure we have at least k+1 entry
 		chainIndexedBlocks := vdatagen.GetRandomIndexedBlocks(numBlocks)
-		baseHeight := uint64(chainIndexedBlocks[0].Height)
+		baseHeight := chainIndexedBlocks[0].Height
+		bestHeight := chainIndexedBlocks[len(chainIndexedBlocks)-1].Height
 		ctl := gomock.NewController(t)
 		mockBtcClient := mocks.NewMockBTCClient(ctl)
 		confirmedBlocks := chainIndexedBlocks[:numBlocks-k]
-		tailChain := chainIndexedBlocks[numBlocks-k:]
 		mockBtcClient.EXPECT().MustSubscribeBlocks().Return().AnyTimes()
-		mockBtcClient.EXPECT().FindTailBlocksByHeight(baseHeight).Return(chainIndexedBlocks, nil).AnyTimes()
+		mockBtcClient.EXPECT().GetBestBlock().Return(nil, uint64(bestHeight), nil)
+		for i := 0; i < int(numBlocks); i++ {
+			mockBtcClient.EXPECT().GetBlockByHeight(gomock.Eq(uint64(chainIndexedBlocks[i].Height))).
+				Return(chainIndexedBlocks[i], nil, nil).AnyTimes()
+		}
 
 		cache, err := types.NewBTCCache(numBlocks)
 		require.NoError(t, err)
 		btcScanner := &btcscanner.BtcScanner{
 			BtcClient:             mockBtcClient,
-			BaseHeight:            baseHeight,
+			BaseHeight:            uint64(baseHeight),
 			K:                     k,
 			ConfirmedBlocksChan:   make(chan *types.IndexedBlock),
 			UnconfirmedBlockCache: cache,
@@ -47,8 +53,6 @@ func FuzzBootStrap(f *testing.F) {
 			}
 		}()
 		btcScanner.Bootstrap()
-		require.Equal(t, uint64(len(tailChain)), btcScanner.UnconfirmedBlockCache.Size())
-		require.Equal(t, tailChain[len(tailChain)-1].BlockHash(), btcScanner.UnconfirmedBlockCache.Tip().BlockHash())
 		require.True(t, btcScanner.Synced.Load())
 	})
 }

--- a/testutil/mocks/btcclient.go
+++ b/testutil/mocks/btcclient.go
@@ -100,6 +100,22 @@ func (mr *MockBTCClientMockRecorder) GetBlockByHash(blockHash interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHash", reflect.TypeOf((*MockBTCClient)(nil).GetBlockByHash), blockHash)
 }
 
+// GetBlockByHeight mocks base method.
+func (m *MockBTCClient) GetBlockByHeight(height uint64) (*types.IndexedBlock, *wire.MsgBlock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlockByHeight", height)
+	ret0, _ := ret[0].(*types.IndexedBlock)
+	ret1, _ := ret[1].(*wire.MsgBlock)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBlockByHeight indicates an expected call of GetBlockByHeight.
+func (mr *MockBTCClientMockRecorder) GetBlockByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockBTCClient)(nil).GetBlockByHeight), height)
+}
+
 // MustSubscribeBlocks mocks base method.
 func (m *MockBTCClient) MustSubscribeBlocks() {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR fixed #153.

Previously, the bootstrapping downloaded all the BTC blocks from the base height to the latest height at once. This will cause an out-of-memory bug when the bootstrapping starts from far behind. This PR fixed this by downloading a single block each time and only proceeding to the next block after the previous block is done.

This PR doesn't use batching because there's no difference in doing it one by one