### PR TITLE
chore: Monitor/Optimize memory usage by removing confirmed blocks out of cache during bootstrapping

### DIFF
--- a/monitor/btcscanner/block_handler.go
+++ b/monitor/btcscanner/block_handler.go
@@ -3,6 +3,7 @@ package btcscanner
 import (
 	"errors"
 	"fmt"
+
 	"github.com/babylonchain/vigilante/types"
 )
 
@@ -73,11 +74,12 @@ func (bs *BtcScanner) handleConnectedBlocks(event *types.BlockEvent) error {
 
 	// otherwise, add the block to the cache
 	bs.UnconfirmedBlockCache.Add(ib)
-	l := bs.UnconfirmedBlockCache.Size()
+
 	// still unconfirmed
-	if l <= bs.K {
+	if bs.UnconfirmedBlockCache.Size() <= bs.K {
 		return nil
 	}
+
 	confirmedBlocks := bs.UnconfirmedBlockCache.TrimConfirmedBlocks(int(bs.K))
 	if confirmedBlocks == nil {
 		return nil

--- a/monitor/btcscanner/btc_scanner.go
+++ b/monitor/btcscanner/btc_scanner.go
@@ -116,7 +116,7 @@ func (bs *BtcScanner) Start() {
 func (bs *BtcScanner) Bootstrap() {
 	var (
 		firstUnconfirmedHeight uint64
-		confirmedBlocks        []*types.IndexedBlock
+		confirmedBlock         *types.IndexedBlock
 		err                    error
 	)
 
@@ -141,28 +141,41 @@ func (bs *BtcScanner) Bootstrap() {
 	if err != nil {
 		panic(fmt.Errorf("cannot get the best BTC block"))
 	}
-	for ; firstUnconfirmedHeight <= bestHeight; firstUnconfirmedHeight++ {
-		ib, _, err := bs.BtcClient.GetBlockByHeight(firstUnconfirmedHeight)
+
+	bestConfirmedHeight := bestHeight - bs.K
+	for i := firstUnconfirmedHeight; i <= bestHeight; i++ {
+		ib, _, err := bs.BtcClient.GetBlockByHeight(i)
 		if err != nil {
 			panic(err)
 		}
 
-		bs.UnconfirmedBlockCache.Add(ib)
+		// add unconfirmed blocks into the cache
+		// the unconfirmed blocks must follow the canonical chain
+		if i > bestConfirmedHeight {
+			tipCache := bs.UnconfirmedBlockCache.Tip()
+			if tipCache != nil {
+				tipHash := tipCache.BlockHash()
+				if !tipHash.IsEqual(&ib.Header.PrevBlock) {
+					panic("invalid canonical chain")
+				}
+			}
 
-		confirmedBlocks = bs.UnconfirmedBlockCache.TrimConfirmedBlocks(int(bs.K))
-		if confirmedBlocks == nil {
+			bs.UnconfirmedBlockCache.Add(ib)
 			continue
 		}
+
+		// this is a confirmed block
+		confirmedBlock = ib
 
 		// if the scanner was bootstrapped before, the new confirmed canonical chain must connect to the previous one
 		if bs.confirmedTipBlock != nil {
 			confirmedTipHash := bs.confirmedTipBlock.BlockHash()
-			if !confirmedTipHash.IsEqual(&confirmedBlocks[0].Header.PrevBlock) {
+			if !confirmedTipHash.IsEqual(&confirmedBlock.Header.PrevBlock) {
 				panic("invalid canonical chain")
 			}
 		}
 
-		bs.sendConfirmedBlocksToChan(confirmedBlocks)
+		bs.sendConfirmedBlocksToChan([]*types.IndexedBlock{confirmedBlock})
 	}
 	log.Infof("bootstrapping is finished at the tip confirmed height: %d",
 		bs.confirmedTipBlock.Height)

--- a/types/btccache.go
+++ b/types/btccache.go
@@ -151,11 +151,9 @@ func (b *BTCCache) TrimConfirmedBlocks(k int) []*IndexedBlock {
 		return nil
 	}
 
-	res := make([]*IndexedBlock, l-k)
-	copy(res, b.blocks)
 	b.blocks = b.blocks[l-k:]
 
-	return res
+	return b.blocks
 }
 
 // FindBlock uses binary search to find the block with the given height in cache

--- a/types/btccache.go
+++ b/types/btccache.go
@@ -151,9 +151,11 @@ func (b *BTCCache) TrimConfirmedBlocks(k int) []*IndexedBlock {
 		return nil
 	}
 
+	res := make([]*IndexedBlock, l-k)
+	copy(res, b.blocks)
 	b.blocks = b.blocks[l-k:]
 
-	return b.blocks
+	return res
 }
 
 // FindBlock uses binary search to find the block with the given height in cache


### PR DESCRIPTION
The out-of-mem problem still exists after deploying #155. The cause might be that confirmed blocks were stored in the cache, which was not released in time. This PR fixed this by not storing confirmed blocks in the cache but processing them directly.