### PR TITLE
feat: Add babylon-related metrics

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -100,8 +100,12 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 	if err != nil {
 		panic(fmt.Errorf("failed to create BTC scanner: %w", err))
 	}
+
+	// register monitor metrics
+	monitorMetrics := metrics.NewMonitorMetrics()
+
 	// create monitor
-	vigilanteMonitor, err = monitor.New(&cfg.Monitor, genesisInfo, btcScanner, bbnQueryClient)
+	vigilanteMonitor, err = monitor.New(&cfg.Monitor, genesisInfo, btcScanner, bbnQueryClient, monitorMetrics)
 	if err != nil {
 		panic(fmt.Errorf("failed to create vigilante monitor: %w", err))
 	}
@@ -117,7 +121,7 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 	server.Start()
 	// start Prometheus metrics server
 	addr := fmt.Sprintf("%s:%d", cfg.Metrics.Host, cfg.Metrics.ServerPort)
-	metrics.Start(addr)
+	metrics.Start(addr, monitorMetrics.Registry)
 
 	// SIGINT handling stuff
 	utils.AddInterruptHandler(func() {

--- a/cmd/reporter/reporter.go
+++ b/cmd/reporter/reporter.go
@@ -72,6 +72,9 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 		panic(fmt.Errorf("failed to open Babylon client: %w", err))
 	}
 
+	// register reporter metrics
+	reporterMetrics := metrics.NewReporterMetrics()
+
 	// create reporter
 	vigilantReporter, err = reporter.New(
 		&cfg.Reporter,
@@ -79,6 +82,7 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 		babylonClient,
 		cfg.Common.RetrySleepTime,
 		cfg.Common.MaxRetrySleepTime,
+		reporterMetrics,
 	)
 	if err != nil {
 		panic(fmt.Errorf("failed to create vigilante reporter: %w", err))
@@ -100,7 +104,7 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 	server.Start()
 	// start Prometheus metrics server
 	addr := fmt.Sprintf("%s:%d", cfg.Metrics.Host, cfg.Metrics.ServerPort)
-	metrics.Start(addr)
+	metrics.Start(addr, reporterMetrics.Registry)
 
 	// SIGINT handling stuff
 	utils.AddInterruptHandler(func() {

--- a/cmd/submitter/submitter.go
+++ b/cmd/submitter/submitter.go
@@ -71,8 +71,11 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 		panic(fmt.Errorf("invalid submitter address from config: %w", err))
 	}
 
+	// create submitter metrics
+	submitterMetrics := metrics.NewSubmitterMetrics()
+
 	// create submitter
-	vigilantSubmitter, err := submitter.New(&cfg.Submitter, btcWallet, queryClient, submitterAddr, cfg.Babylon.TagIdx)
+	vigilantSubmitter, err := submitter.New(&cfg.Submitter, btcWallet, queryClient, submitterAddr, cfg.Babylon.TagIdx, submitterMetrics)
 	if err != nil {
 		panic(fmt.Errorf("failed to create vigilante submitter: %w", err))
 	}
@@ -91,7 +94,7 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 
 	// start Prometheus metrics server
 	addr := fmt.Sprintf("%s:%d", cfg.Metrics.Host, cfg.Metrics.ServerPort)
-	metrics.Start(addr)
+	metrics.Start(addr, submitterMetrics.Registry)
 
 	// SIGINT handling stuff
 	utils.AddInterruptHandler(func() {

--- a/cmd/submitter/submitter.go
+++ b/cmd/submitter/submitter.go
@@ -71,7 +71,7 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 		panic(fmt.Errorf("invalid submitter address from config: %w", err))
 	}
 
-	// create submitter metrics
+	// register submitter metrics
 	submitterMetrics := metrics.NewSubmitterMetrics()
 
 	// create submitter

--- a/metrics/monitor.go
+++ b/metrics/monitor.go
@@ -22,7 +22,7 @@ func NewMonitorMetrics() *MonitorMetrics {
 		Registry: registry,
 		ValidEpochsCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_monitor_valid_epochs",
-			Help: "The total number of verified epochs",
+			Help: "The total number of valid epochs",
 		}),
 		InvalidEpochsCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_monitor_invalid_epochs",

--- a/metrics/monitor.go
+++ b/metrics/monitor.go
@@ -33,7 +33,7 @@ func NewMonitorMetrics() *MonitorMetrics {
 			Help: "The total number of valid BTC headers",
 		}),
 		InvalidBTCHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
-			Name: "vigilante_monitor_invalid_epochs",
+			Name: "vigilante_monitor_invalid_btc_headers",
 			Help: "The total number of invalid BTC headers",
 		}),
 		LivenessAttacksCounter: registerer.NewCounter(prometheus.CounterOpts{

--- a/metrics/monitor.go
+++ b/metrics/monitor.go
@@ -1,0 +1,45 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type MonitorMetrics struct {
+	Registry                 *prometheus.Registry
+	ValidEpochsCounter       prometheus.Counter
+	InvalidEpochsCounter     prometheus.Counter
+	ValidBTCHeadersCounter   prometheus.Counter
+	InvalidBTCHeadersCounter prometheus.Counter
+	LivenessAttacksCounter   prometheus.Counter
+}
+
+func NewMonitorMetrics() *MonitorMetrics {
+	registry := prometheus.NewRegistry()
+	registerer := promauto.With(registry)
+
+	metrics := &MonitorMetrics{
+		Registry: registry,
+		ValidEpochsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_monitor_valid_epochs",
+			Help: "The total number of verified epochs",
+		}),
+		InvalidEpochsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_monitor_invalid_epochs",
+			Help: "The total number of invalid epochs",
+		}),
+		ValidBTCHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_monitor_valid_btc_headers",
+			Help: "The total number of valid BTC headers",
+		}),
+		InvalidBTCHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_monitor_invalid_epochs",
+			Help: "The total number of invalid BTC headers",
+		}),
+		LivenessAttacksCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_monitor_liveness_attacks",
+			Help: "The total number of detected liveness attacks",
+		}),
+	}
+	return metrics
+}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -9,20 +9,16 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func Start(addr string) {
-	go start(addr)
+func Start(addr string, reg *prometheus.Registry) {
+	go start(addr, reg)
 }
 
-func start(addr string) {
-	// Create a new registry.
-	reg := prometheus.NewRegistry()
-
+func start(addr string, reg *prometheus.Registry) {
 	// Add Go module build info.
 	reg.MustRegister(collectors.NewBuildInfoCollector())
 	reg.MustRegister(collectors.NewGoCollector(
 		collectors.WithGoCollections(collectors.GoRuntimeMemStatsCollection | collectors.GoRuntimeMetricsCollection),
 	))
-	// TODO: add more metrics
 
 	// Expose the registered metrics via HTTP.
 	http.Handle("/metrics", promhttp.HandlerFor(

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -25,11 +25,11 @@ func NewReporterMetrics() *ReporterMetrics {
 		Registry: registry,
 		SuccessfulHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_reporter_reported_headers",
-			Help: "The total number of reported BTC headers to Babylon",
+			Help: "The total number of BTC headers reported to Babylon",
 		}),
 		SuccessfulCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_reporter_reported_checkpoints",
-			Help: "The total number of reported BTC checkpoints to Babylon",
+			Help: "The total number of BTC checkpoints reported to Babylon",
 		}),
 		FailedHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_reporter_failed_headers",
@@ -41,7 +41,7 @@ func NewReporterMetrics() *ReporterMetrics {
 		}),
 		SecondsSinceLastHeaderGauge: registerer.NewGauge(prometheus.GaugeOpts{
 			Name: "vigilante_reporter_since_last_header_seconds",
-			Help: "Seconds since the last successful reported BTC checkpoint to Babylon",
+			Help: "Seconds since the last successful reported BTC header to Babylon",
 		}),
 		SecondsSinceLastCheckpointGauge: registerer.NewGauge(prometheus.GaugeOpts{
 			Name: "vigilante_reporter_since_last_checkpoint_seconds",
@@ -55,6 +55,7 @@ func (sm *ReporterMetrics) RecordMetrics() {
 	go func() {
 		for {
 			time.Sleep(1 * time.Second)
+			// will be reset when a header/checkpoint is successfully sent
 			sm.SecondsSinceLastHeaderGauge.Inc()
 			sm.SecondsSinceLastCheckpointGauge.Inc()
 		}

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -53,8 +53,8 @@ func NewReporterMetrics() *ReporterMetrics {
 
 func (sm *ReporterMetrics) RecordMetrics() {
 	go func() {
-		for {
-			time.Sleep(1 * time.Second)
+		ticker := time.NewTicker(1 * time.Second)
+		for range ticker.C {
 			// will be reset when a header/checkpoint is successfully sent
 			sm.SecondsSinceLastHeaderGauge.Inc()
 			sm.SecondsSinceLastCheckpointGauge.Inc()

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -44,7 +44,7 @@ func NewReporterMetrics() *ReporterMetrics {
 			Help: "Seconds since the last successful reported BTC checkpoint to Babylon",
 		}),
 		SecondsSinceLastCheckpointGauge: registerer.NewGauge(prometheus.GaugeOpts{
-			Name: "vigilante_reporter_since_last_submission_seconds",
+			Name: "vigilante_reporter_since_last_checkpoint_seconds",
 			Help: "Seconds since the last successful reported BTC checkpoint to Babylon",
 		}),
 	}

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type ReporterMetrics struct {
+	Registry                        *prometheus.Registry
+	SuccessfulHeadersCounter        prometheus.Counter
+	SuccessfulCheckpointsCounter    prometheus.Counter
+	FailedHeadersCounter            prometheus.Counter
+	FailedCheckpointsCounter        prometheus.Counter
+	SecondsSinceLastHeaderGauge     prometheus.Gauge
+	SecondsSinceLastCheckpointGauge prometheus.Gauge
+}
+
+func NewReporterMetrics() *ReporterMetrics {
+	registry := prometheus.NewRegistry()
+	registerer := promauto.With(registry)
+
+	metrics := &ReporterMetrics{
+		Registry: registry,
+		SuccessfulHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_reporter_reported_headers",
+			Help: "The total number of reported BTC headers to Babylon",
+		}),
+		SuccessfulCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_reporter_reported_checkpoints",
+			Help: "The total number of reported BTC checkpoints to Babylon",
+		}),
+		FailedHeadersCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_reporter_failed_headers",
+			Help: "The total number of failed BTC headers to Babylon",
+		}),
+		FailedCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_reporter_failed_checkpoints",
+			Help: "The total number of failed BTC checkpoints to Babylon",
+		}),
+		SecondsSinceLastHeaderGauge: registerer.NewGauge(prometheus.GaugeOpts{
+			Name: "vigilante_reporter_since_last_header_seconds",
+			Help: "Seconds since the last successful reported BTC checkpoint to Babylon",
+		}),
+		SecondsSinceLastCheckpointGauge: registerer.NewGauge(prometheus.GaugeOpts{
+			Name: "vigilante_reporter_since_last_submission_seconds",
+			Help: "Seconds since the last successful reported BTC checkpoint to Babylon",
+		}),
+	}
+	return metrics
+}
+
+func (sm *ReporterMetrics) RecordMetrics() {
+	go func() {
+		for {
+			time.Sleep(1 * time.Second)
+			sm.SecondsSinceLastHeaderGauge.Inc()
+			sm.SecondsSinceLastCheckpointGauge.Inc()
+		}
+	}()
+
+}

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -22,7 +22,7 @@ func NewSubmitterMetrics() *SubmitterMetrics {
 		Registry: registry,
 		SuccessfulCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_submitter_submitted_checkpoints",
-			Help: "The total number of submitted checkpoints to BTC",
+			Help: "The total number of raw checkpoints submitted to BTC",
 		}),
 		FailedCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_submitter_failed_checkpoints",
@@ -40,6 +40,7 @@ func (sm *SubmitterMetrics) RecordMetrics() {
 	go func() {
 		for {
 			time.Sleep(1 * time.Second)
+			// will be reset when a checkpoint is successfully submitted
 			sm.SecondsSinceLastCheckpointGauge.Inc()
 		}
 	}()

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -38,8 +38,8 @@ func NewSubmitterMetrics() *SubmitterMetrics {
 
 func (sm *SubmitterMetrics) RecordMetrics() {
 	go func() {
-		for {
-			time.Sleep(1 * time.Second)
+		ticker := time.NewTicker(1 * time.Second)
+		for range ticker.C {
 			// will be reset when a checkpoint is successfully submitted
 			sm.SecondsSinceLastCheckpointGauge.Inc()
 		}

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -1,0 +1,46 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type SubmitterMetrics struct {
+	Registry                        *prometheus.Registry
+	SuccessfulCheckpointsCounter    prometheus.Counter
+	FailedCheckpointsCounter        prometheus.Counter
+	SecondsSinceLastCheckpointGauge prometheus.Gauge
+}
+
+func NewSubmitterMetrics() *SubmitterMetrics {
+	registry := prometheus.NewRegistry()
+	registerer := promauto.With(registry)
+
+	metrics := &SubmitterMetrics{
+		Registry: registry,
+		SuccessfulCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_submitter_submitted_checkpoints",
+			Help: "The total number of submitted checkpoints to BTC",
+		}),
+		FailedCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_submitter_failed_checkpoints",
+			Help: "The total number of failed checkpoints to BTC",
+		}),
+		SecondsSinceLastCheckpointGauge: registerer.NewGauge(prometheus.GaugeOpts{
+			Name: "vigilante_submitter_since_last_checkpoint_seconds",
+			Help: "Seconds since the last successful submitted checkpoint",
+		}),
+	}
+	return metrics
+}
+
+func (sm *SubmitterMetrics) RecordMetrics() {
+	go func() {
+		for {
+			time.Sleep(1 * time.Second)
+			sm.SecondsSinceLastCheckpointGauge.Inc()
+		}
+	}()
+}

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -30,7 +30,7 @@ func NewSubmitterMetrics() *SubmitterMetrics {
 		}),
 		SecondsSinceLastCheckpointGauge: registerer.NewGauge(prometheus.GaugeOpts{
 			Name: "vigilante_submitter_since_last_checkpoint_seconds",
-			Help: "Seconds since the last successful submitted checkpoint",
+			Help: "Seconds since the last successfully submitted checkpoint",
 		}),
 	}
 	return metrics

--- a/monitor/liveness_checker.go
+++ b/monitor/liveness_checker.go
@@ -27,8 +27,8 @@ func (m *Monitor) runLivenessChecker() {
 			for _, c := range checkpoints {
 				err := m.CheckLiveness(c)
 				if err != nil {
-					// TODO decide what to do with this error, sending an alarm?
 					log.Errorf("the checkpoint at epoch %d is detected being censored: %s", c.EpochNum(), err.Error())
+					m.metrics.LivenessAttacksCounter.Inc()
 					continue
 				}
 				log.Debugf("the checkpoint at epoch %d has passed the liveness check", c.EpochNum())

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -50,8 +50,8 @@ func (r *Reporter) submitHeadersDedup(signer sdk.AccAddress, headers []*wire.Blo
 	})
 
 	if err != nil {
-		return 0, fmt.Errorf("failed to submit headers: %w", err)
 		r.metrics.FailedHeadersCounter.Add(float64(numSubmitted))
+		return 0, fmt.Errorf("failed to submit headers: %w", err)
 	}
 
 	r.metrics.SuccessfulHeadersCounter.Add(float64(numSubmitted))

--- a/reporter/utils.go
+++ b/reporter/utils.go
@@ -1,6 +1,8 @@
 package reporter
 
 import (
+	"fmt"
+
 	"github.com/babylonchain/babylon/types/retry"
 	btcctypes "github.com/babylonchain/babylon/x/btccheckpoint/types"
 	btclctypes "github.com/babylonchain/babylon/x/btclightclient/types"
@@ -37,6 +39,7 @@ func (r *Reporter) submitHeadersDedup(signer sdk.AccAddress, headers []*wire.Blo
 			msgInsertHeader := types.NewMsgInsertHeader(r.babylonClient.GetConfig().AccountPrefix, signer, header)
 			msgs = append(msgs, msgInsertHeader)
 		}
+		// TODO would this cause any issues if the number of unsubmitted headers is very large?
 		res, err = r.babylonClient.InsertHeaders(msgs)
 		if err != nil {
 			return err
@@ -45,6 +48,15 @@ func (r *Reporter) submitHeadersDedup(signer sdk.AccAddress, headers []*wire.Blo
 		log.Infof("Successfully submitted %d headers to Babylon with response code %v", len(msgs), res.Code)
 		return nil
 	})
+
+	if err != nil {
+		return 0, fmt.Errorf("failed to submit headers: %w", err)
+		r.metrics.FailedHeadersCounter.Add(float64(numSubmitted))
+	}
+
+	r.metrics.SuccessfulHeadersCounter.Add(float64(numSubmitted))
+	r.metrics.SecondsSinceLastHeaderGauge.Set(0)
+
 	return numSubmitted, err
 }
 
@@ -143,9 +155,12 @@ func (r *Reporter) matchAndSubmitCheckpoints(signer sdk.AccAddress) (int, error)
 		res, err = r.babylonClient.InsertBTCSpvProof(msgInsertBTCSpvProof)
 		if err != nil {
 			log.Errorf("Failed to submit MsgInsertBTCSpvProof with error %v", err)
+			r.metrics.FailedCheckpointsCounter.Inc()
 			continue
 		}
 		log.Infof("Successfully submitted MsgInsertBTCSpvProof with response %d", res.Code)
+		r.metrics.SuccessfulCheckpointsCounter.Inc()
+		r.metrics.SecondsSinceLastCheckpointGauge.Set(0)
 	}
 
 	return numMatchedCkpts, nil

--- a/reporter/utils_test.go
+++ b/reporter/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonchain/vigilante/config"
+	"github.com/babylonchain/vigilante/metrics"
 	"github.com/babylonchain/vigilante/reporter"
 	vdatagen "github.com/babylonchain/vigilante/testutil/datagen"
 	"github.com/babylonchain/vigilante/testutil/mocks"
@@ -37,6 +38,7 @@ func newMockReporter(t *testing.T, ctrl *gomock.Controller) (
 		mockBabylonClient,
 		cfg.Common.RetrySleepTime,
 		cfg.Common.MaxRetrySleepTime,
+		metrics.NewReporterMetrics(),
 	)
 	require.NoError(t, err)
 

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -8,15 +8,16 @@ import (
 
 	"github.com/babylonchain/babylon/btctxformatter"
 	ckpttypes "github.com/babylonchain/babylon/x/checkpointing/types"
-	"github.com/babylonchain/vigilante/btcclient"
-	"github.com/babylonchain/vigilante/log"
-	"github.com/babylonchain/vigilante/types"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/jinzhu/copier"
+
+	"github.com/babylonchain/vigilante/btcclient"
+	"github.com/babylonchain/vigilante/log"
+	"github.com/babylonchain/vigilante/types"
 )
 
 type Relayer struct {
@@ -50,7 +51,7 @@ func (rl *Relayer) SendCheckpointToBTC(ckpt *ckpttypes.RawCheckpointWithMeta) er
 	}
 	if !rl.sentCheckpoints.ShouldSend(ckpt.Ckpt.EpochNum) {
 		log.Logger.Debugf("Skip submitting the raw checkpoint for epoch %v", ckpt.Ckpt.EpochNum)
-		return errors.New("checkpoint has already been submitted")
+		return nil
 	}
 	log.Logger.Debugf("Submitting a raw checkpoint for epoch %v", ckpt.Ckpt.EpochNum)
 	err := rl.convertCkptToTwoTxAndSubmit(ckpt)


### PR DESCRIPTION
This PR adds Babylon-related metrics for monitoring purposes. The metrics and alarming rules are described as follows. cc @philmln.

* reporter
    * "vigilante_reporter_reported_headers", "The total number of reported BTC headers to Babylon"
    * "vigilante_reporter_reported_checkpoints", "The total number of reported BTC checkpoints to Babylon"
    * "vigilante_reporter_failed_headers", "The total number of failed BTC headers to Babylon", should alarm when this metric > 0
    * "vigilante_reporter_failed_checkpoints", "The total number of failed BTC checkpoints to Babylon", should alarm when this metric > 0
    * "vigilante_reporter_since_last_header_seconds", "Seconds since the last successful reported BTC checkpoint to Babylon", should alarm when this metric > X
    * "vigilante_reporter_since_last_submission_seconds", "Seconds since the last successful reported BTC checkpoint to Babylon", should alarm when this metric > X
* submitter
    * "vigilante_submitter_submitted_checkpoints", "The total number of submitted checkpoints to BTC"
    * "vigilante_submitter_failed_checkpoints", "The total number of failed checkpoints to BTC", should alarm when this metric > 0
    * "vigilante_submitter_since_last_checkpoint_seconds", "Seconds since the last successfully submitted checkpoint", should alarm when this metric > X
* monitor
    * "vigilante_monitor_valid_epochs", "The total number of verified epochs"
    * "vigilante_monitor_invalid_epochs", "The total number of invalid epochs", should alarm when this metric > 0
    * "vigilante_monitor_valid_btc_headers", "The total number of valid BTC headers"
    * "vigilante_monitor_invalid_epochs", "The total number of invalid BTC headers", should alarm when this metric > 0
    * "vigilante_monitor_liveness_attacks", "The total number of detected liveness attacks", should alarm when this metric > 0
