### PR TITLE
fix: Fix the issue of the monitor thread blocking the start of the rpc server

### DIFF
--- a/cmd/monitor/monitor.go
+++ b/cmd/monitor/monitor.go
@@ -111,7 +111,7 @@ func cmdFunc(cmd *cobra.Command, args []string) {
 		panic(fmt.Errorf("failed to create monitor's RPC server: %w", err))
 	}
 
-	vigilanteMonitor.Start()
+	go vigilanteMonitor.Start()
 
 	// start RPC server
 	server.Start()


### PR DESCRIPTION
As reported by @philmln. The RPC server and the Prometheus server of the vigilante monitor were blocked by the monitor thread. This PR fixed this by putting the thread into a goroutine.