### PR TITLE
fix: fix potential memory leak in BTCCache

### DIFF
--- a/types/btccache.go
+++ b/types/btccache.go
@@ -58,10 +58,13 @@ func (b *BTCCache) Add(ib *IndexedBlock) {
 
 // Thread-unsafe version of Add
 func (b *BTCCache) add(ib *IndexedBlock) {
-	if b.size() >= b.maxEntries {
-		// dereference the 0-th block to ensure it will be garbage-collected
-		// see https://stackoverflow.com/questions/55045402/memory-leak-in-golang-slice
-		b.blocks[0] = nil
+	if b.size() > b.maxEntries {
+		panic(ErrTooManyEntries)
+	}
+	if b.size() == b.maxEntries {
+		// // dereference the 0-th block to ensure it will be garbage-collected
+		// // see https://stackoverflow.com/questions/55045402/memory-leak-in-golang-slice
+		// b.blocks[0] = nil
 		b.blocks = b.blocks[1:]
 	}
 

--- a/types/btccache.go
+++ b/types/btccache.go
@@ -62,9 +62,9 @@ func (b *BTCCache) add(ib *IndexedBlock) {
 		panic(ErrTooManyEntries)
 	}
 	if b.size() == b.maxEntries {
-		// // dereference the 0-th block to ensure it will be garbage-collected
-		// // see https://stackoverflow.com/questions/55045402/memory-leak-in-golang-slice
-		// b.blocks[0] = nil
+		// dereference the 0-th block to ensure it will be garbage-collected
+		// see https://stackoverflow.com/questions/55045402/memory-leak-in-golang-slice
+		b.blocks[0] = nil
 		b.blocks = b.blocks[1:]
 	}
 

--- a/types/btccache.go
+++ b/types/btccache.go
@@ -59,6 +59,9 @@ func (b *BTCCache) Add(ib *IndexedBlock) {
 // Thread-unsafe version of Add
 func (b *BTCCache) add(ib *IndexedBlock) {
 	if b.size() >= b.maxEntries {
+		// dereference the 0-th block to ensure it will be garbage-collected
+		// see https://stackoverflow.com/questions/55045402/memory-leak-in-golang-slice
+		b.blocks[0] = nil
 		b.blocks = b.blocks[1:]
 	}
 
@@ -85,6 +88,8 @@ func (b *BTCCache) RemoveLast() error {
 		return ErrEmptyCache
 	}
 
+	// dereference the last block to ensure it will be garbage-collected
+	b.blocks[len(b.blocks)-1] = nil
 	b.blocks = b.blocks[:len(b.blocks)-1]
 	return nil
 }
@@ -94,7 +99,7 @@ func (b *BTCCache) RemoveAll() {
 	b.Lock()
 	defer b.Unlock()
 
-	b.blocks = b.blocks[:0]
+	b.blocks = []*IndexedBlock{}
 }
 
 // Size returns the size of the cache. Thread-safe.
@@ -208,6 +213,11 @@ func (b *BTCCache) Trim() {
 	// cache size is smaller than maxEntries, can't trim
 	if b.size() < b.maxEntries {
 		return
+	}
+
+	// dereference b.blocks[:len(b.blocks)-int(b.maxEntries)] to ensure they will be garbage-collected
+	for i := range b.blocks[:len(b.blocks)-int(b.maxEntries)] {
+		b.blocks[i] = nil
 	}
 
 	b.blocks = b.blocks[len(b.blocks)-int(b.maxEntries):]


### PR DESCRIPTION
This PR fixed a potential memory leak issue in BTCCache. To remove an element in a slice, one needs to first dereference it [so that the dereferenced object will be garbage-collected](https://stackoverflow.com/questions/55045402/memory-leak-in-golang-slice). This PR is based on a detailed discussion with @vitsalis and @KonradStaniec 

Tested docker deployment locally and the PR does not affect current logic