### PR TITLE
fix: Submitter/Fix bumping fee

### DIFF
--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -1,15 +1,16 @@
 package btcclient
 
 import (
-	"github.com/babylonchain/vigilante/config"
-	"github.com/babylonchain/vigilante/netparams"
-	"github.com/babylonchain/vigilante/types"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
+
+	"github.com/babylonchain/vigilante/config"
+	"github.com/babylonchain/vigilante/netparams"
+	"github.com/babylonchain/vigilante/types"
 )
 
 // NewWallet creates a new BTC wallet

--- a/btcclient/interface.go
+++ b/btcclient/interface.go
@@ -2,10 +2,10 @@ package btcclient
 
 import (
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcd/btcutil"
 
 	"github.com/babylonchain/vigilante/types"
 )

--- a/config/bitcoin.go
+++ b/config/bitcoin.go
@@ -3,8 +3,9 @@ package config
 import (
 	"errors"
 
-	"github.com/babylonchain/vigilante/types"
 	"github.com/btcsuite/btcd/btcutil"
+
+	"github.com/babylonchain/vigilante/types"
 )
 
 // BTCConfig defines configuration for the Bitcoin client

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -471,7 +471,7 @@ func TestSubmitterSubmissionReplace(t *testing.T) {
 
 	// mine a block with those replacement transactions just to be sure they execute correctly
 	sendTransactions[1] = resendTx2
-	blockWithOpReturnTranssactions := mineBlockWithTxes(t, tm.MinerNode, sendTransactions)
+	blockWithOpReturnTransactions := mineBlockWithTxes(t, tm.MinerNode, sendTransactions)
 	// block should have 2 transactions, 1 from submitter and 1 coinbase
-	require.Equal(t, len(blockWithOpReturnTranssactions.Transactions), 3)
+	require.Equal(t, len(blockWithOpReturnTransactions.Transactions), 3)
 }

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -443,6 +443,9 @@ func TestSubmitterSubmissionReplace(t *testing.T) {
 		return len(submittedTransactions) == 2
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 
+	// hack: tune the TxFeeMin to make sure the resending is triggered
+	tm.BtcWalletClient.Cfg.TxFeeMin = btcutil.Amount(10000)
+
 	sendTransactions := retrieveTransactionFromMempool(t, tm.MinerNode, submittedTransactions)
 
 	// at this point our submitter already sent 2 checkpoint transactions which landed in mempool.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/cometbft/cometbft v0.37.1
 	github.com/cosmos/cosmos-sdk v0.47.2
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/golang/mock v1.6.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
@@ -78,7 +79,6 @@ require (
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.4 // indirect
 	github.com/dgraph-io/ristretto v0.1.1 // indirect

--- a/submitter/relayer/change_address_test.go
+++ b/submitter/relayer/change_address_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonchain/babylon/btctxformatter"
+
 	"github.com/babylonchain/vigilante/netparams"
 	"github.com/babylonchain/vigilante/submitter/relayer"
 	"github.com/babylonchain/vigilante/testutil/mocks"

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -147,8 +147,8 @@ func (rl *Relayer) resendSecondTxOfCheckpointToBTC(ckptInfo *types.CheckpointInf
 // calcMinRequiredTxReplacementFee returns the minimum transaction fee required for a
 // transaction with the passed serialized size to be accepted into the memory
 // pool and relayed.
+// Adapted from https://github.com/btcsuite/btcd/blob/f9cbff0d819c951d20b85714cf34d7f7cc0a44b7/mempool/policy.go#L61
 func calcMinRequiredTxReplacementFee(serializedSize uint64, minRelayTxFee uint64) uint64 {
-	// Adapted from https://github.com/btcsuite/btcd/blob/f9cbff0d819c951d20b85714cf34d7f7cc0a44b7/mempool/policy.go#L61
 	// Calculate the minimum fee for a transaction to be allowed into the
 	// mempool and relayed by scaling the base fee (which is the minimum
 	// free transaction relay fee).  minRelayTxFee is in Satoshi/kB so
@@ -162,7 +162,7 @@ func calcMinRequiredTxReplacementFee(serializedSize uint64, minRelayTxFee uint64
 
 	// Set the minimum fee to the maximum possible value if the calculated
 	// fee is not in the valid range for monetary amounts.
-	if minFee < 0 || minFee > btcutil.MaxSatoshi {
+	if minFee > btcutil.MaxSatoshi {
 		minFee = btcutil.MaxSatoshi
 	}
 

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -97,13 +97,16 @@ func (rl *Relayer) SendCheckpointToBTC(ckpt *ckpttypes.RawCheckpointWithMeta) er
 			return nil
 		}
 
+		log.Logger.Debugf("Resending the second tx of the checkpoint %v, old fee of the second tx: %v Satoshis, txid: %s",
+			ckptEpoch, rl.lastSubmittedCheckpoint.Tx2.Fee, rl.lastSubmittedCheckpoint.Tx2.TxId.String())
+
 		resubmittedTx2, err := rl.resendSecondTxOfCheckpointToBTC(rl.lastSubmittedCheckpoint.Tx2, bumpedFee)
 		if err != nil {
 			return fmt.Errorf("failed to re-send the second tx of the checkpoint %v: %w", rl.lastSubmittedCheckpoint.Epoch, err)
 		}
 
-		log.Logger.Infof("Successfully re-sent the second tx of the checkpoint %v with new tx fee of %v, txid: %s",
-			rl.lastSubmittedCheckpoint.Epoch, resubmittedTx2.Fee, resubmittedTx2.TxId.String())
+		log.Logger.Infof("Successfully re-sent the second tx of the checkpoint %v, txid: %s, bumped fee: %v Satoshis",
+			rl.lastSubmittedCheckpoint.Epoch, resubmittedTx2.TxId.String(), resubmittedTx2.Fee)
 
 		// update the second tx of the last submitted checkpoint as it is replaced
 		rl.lastSubmittedCheckpoint.Tx2 = resubmittedTx2

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -9,16 +9,16 @@ import (
 	"github.com/babylonchain/babylon/btctxformatter"
 	"github.com/babylonchain/babylon/types/retry"
 	btcctypes "github.com/babylonchain/babylon/x/btccheckpoint/types"
-
 	"github.com/babylonchain/rpc-client/query"
 
 	"github.com/babylonchain/vigilante/metrics"
 	"github.com/babylonchain/vigilante/submitter/relayer"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/babylonchain/vigilante/btcclient"
 	"github.com/babylonchain/vigilante/config"
 	"github.com/babylonchain/vigilante/submitter/poller"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type Submitter struct {


### PR DESCRIPTION
As reported by @vitsalis, previously, the bumping fee of the second tx includes the old fee of the first tx, which should not.

The bumped fee should be newly estimated fees of both tx1 and tx2 minus the old fee of the first tx, i.e., `bumpedFee = Fee2(size(tx1)) + Fee2(size(tx2)) - Fee1(size(tx1)`. Also, we should skip resending if `bumpedFee <= Fee1(size(tx2)) + requiredMinTxFee`. Otherwise, the mempool will reject this tx.

In the e2e tests, the estimation fee is always `0 Satoshi/KB`. To make sure the bumping happens, I hacked around it by tuning the `TxFeeMin`. As suggested by @KonradStaniec, maybe in the future, we can make the estimation to be meaningful by mining some blocks in the e2e tests.