### PR TITLE
feat: Add BTC related metrics

### DIFF
--- a/cmd/vigilante/cmd/submitter.go
+++ b/cmd/vigilante/cmd/submitter.go
@@ -66,7 +66,8 @@ func GetSubmitterCmd() *cobra.Command {
 				submitterAddr,
 				cfg.Common.RetrySleepTime,
 				cfg.Common.MaxRetrySleepTime,
-				submitterMetrics)
+				submitterMetrics,
+			)
 			if err != nil {
 				panic(fmt.Errorf("failed to create vigilante submitter: %w", err))
 			}

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -15,6 +15,8 @@ type ReporterMetrics struct {
 	FailedCheckpointsCounter        prometheus.Counter
 	SecondsSinceLastHeaderGauge     prometheus.Gauge
 	SecondsSinceLastCheckpointGauge prometheus.Gauge
+	NewReportedHeaderGaugeVec       *prometheus.GaugeVec
+	NewReportedCheckpointGaugeVec   *prometheus.GaugeVec
 }
 
 func NewReporterMetrics() *ReporterMetrics {
@@ -47,6 +49,32 @@ func NewReporterMetrics() *ReporterMetrics {
 			Name: "vigilante_reporter_since_last_checkpoint_seconds",
 			Help: "Seconds since the last successful reported BTC checkpoint to Babylon",
 		}),
+		NewReportedHeaderGaugeVec: registerer.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "vigilante_reporter_new_btc_header",
+				Help: "The metric of a new BTC header reported to Babylon",
+			},
+			[]string{
+				// the id of the reported BTC header
+				"id",
+			},
+		),
+		NewReportedCheckpointGaugeVec: registerer.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "vigilante_reporter_new_btc_checkpoint",
+				Help: "The metric of a new BTC checkpoint reported to Babylon",
+			},
+			[]string{
+				// the epoch number of the reported checkpoint
+				"epoch",
+				// the BTC height of the reported checkpoint (based on the first tx)
+				"height",
+				// the id of the first BTC tx of the reported checkpoint
+				"tx1id",
+				// the id of the second BTC tx of the reported checkpoint
+				"tx2id",
+			},
+		),
 	}
 	return metrics
 }

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -19,7 +19,6 @@ type RelayerMetrics struct {
 	AvailableBTCBalance                   prometheus.Gauge
 	InvalidCheckpointCounter              prometheus.Counter
 	NewSubmittedCheckpointSegmentGaugeVec *prometheus.GaugeVec
-	// TODO bug alert
 }
 
 func NewRelayerMetrics(registry *prometheus.Registry) *RelayerMetrics {

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -28,7 +28,7 @@ func NewRelayerMetrics(registry *prometheus.Registry) *RelayerMetrics {
 
 	metrics := &RelayerMetrics{
 		ResendIntervalSecondsGauge: registerer.NewGauge(prometheus.GaugeOpts{
-			Name: "vigilante_submitter_resend_intervals",
+			Name: "vigilante_submitter_resend_interval",
 			Help: "The intervals the submitter resends a checkpoint in seconds",
 		}),
 		AvailableBTCBalance: registerer.NewGauge(prometheus.GaugeOpts{

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -18,6 +18,8 @@ type RelayerMetrics struct {
 	ResendIntervalSecondsGauge            prometheus.Gauge
 	AvailableBTCBalance                   prometheus.Gauge
 	InvalidCheckpointCounter              prometheus.Counter
+	ResentCheckpointsCounter              prometheus.Counter
+	FailedResentCheckpointsCounter        prometheus.Counter
 	NewSubmittedCheckpointSegmentGaugeVec *prometheus.GaugeVec
 }
 
@@ -36,6 +38,14 @@ func NewRelayerMetrics(registry *prometheus.Registry) *RelayerMetrics {
 		InvalidCheckpointCounter: registerer.NewCounter(prometheus.CounterOpts{
 			Name: "vigilante_submitter_invalid_checkpoints",
 			Help: "The number of invalid checkpoints (invalid epoch number or status)",
+		}),
+		ResentCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_submitter_resent_checkpoints",
+			Help: "The number of resent checkpoints",
+		}),
+		FailedResentCheckpointsCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_submitter_failed_resent_checkpoints",
+			Help: "The number of failed resent checkpoints",
 		}),
 		NewSubmittedCheckpointSegmentGaugeVec: registerer.NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -14,6 +14,41 @@ type SubmitterMetrics struct {
 	SecondsSinceLastCheckpointGauge prometheus.Gauge
 }
 
+type RelayerMetrics struct {
+	ResendIntervalSecondsGauge            prometheus.Gauge
+	NewSubmittedCheckpointSegmentGaugeVec *prometheus.GaugeVec
+	// TODO bug alert
+}
+
+func NewRelayerMetrics(registry *prometheus.Registry) *RelayerMetrics {
+	registerer := promauto.With(registry)
+
+	metrics := &RelayerMetrics{
+		ResendIntervalSecondsGauge: registerer.NewGauge(prometheus.GaugeOpts{
+			Name: "vigilante_submitter_resend_intervals",
+			Help: "The intervals the submitter resends a checkpoint in seconds",
+		}),
+		NewSubmittedCheckpointSegmentGaugeVec: registerer.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "vigilante_submitter_new_checkpoint_segment",
+				Help: "The metric of a new Babylon checkpoint segment submitted to BTC",
+			},
+			[]string{
+				// the epoch number of the checkpoint segment
+				"epoch",
+				// the index of the checkpoint segment (either 0 or 1)
+				"idx",
+				// the id of the checkpoint segment
+				"txid",
+				// the fee used by submitting the checkpoint segment
+				"fee",
+			},
+		),
+	}
+
+	return metrics
+}
+
 func NewSubmitterMetrics() *SubmitterMetrics {
 	registry := prometheus.NewRegistry()
 	registerer := promauto.With(registry)

--- a/metrics/submitter.go
+++ b/metrics/submitter.go
@@ -16,6 +16,8 @@ type SubmitterMetrics struct {
 
 type RelayerMetrics struct {
 	ResendIntervalSecondsGauge            prometheus.Gauge
+	AvailableBTCBalance                   prometheus.Gauge
+	InvalidCheckpointCounter              prometheus.Counter
 	NewSubmittedCheckpointSegmentGaugeVec *prometheus.GaugeVec
 	// TODO bug alert
 }
@@ -27,6 +29,14 @@ func NewRelayerMetrics(registry *prometheus.Registry) *RelayerMetrics {
 		ResendIntervalSecondsGauge: registerer.NewGauge(prometheus.GaugeOpts{
 			Name: "vigilante_submitter_resend_intervals",
 			Help: "The intervals the submitter resends a checkpoint in seconds",
+		}),
+		AvailableBTCBalance: registerer.NewGauge(prometheus.GaugeOpts{
+			Name: "vigilante_submitter_available_balance",
+			Help: "The available balance in wallet in Satoshis",
+		}),
+		InvalidCheckpointCounter: registerer.NewCounter(prometheus.CounterOpts{
+			Name: "vigilante_submitter_invalid_checkpoints",
+			Help: "The number of invalid checkpoints (invalid epoch number or status)",
 		}),
 		NewSubmittedCheckpointSegmentGaugeVec: registerer.NewGaugeVec(
 			prometheus.GaugeOpts{

--- a/submitter/relayer/change_address_test.go
+++ b/submitter/relayer/change_address_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/babylonchain/babylon/btctxformatter"
+
+	"github.com/babylonchain/vigilante/metrics"
 	"github.com/babylonchain/vigilante/netparams"
 	"github.com/babylonchain/vigilante/submitter/relayer"
 	"github.com/babylonchain/vigilante/testutil/mocks"
@@ -39,7 +41,9 @@ func TestGetChangeAddress(t *testing.T) {
 	require.NoError(t, err)
 	wallet := mocks.NewMockBTCWallet(gomock.NewController(t))
 	wallet.EXPECT().GetNetParams().Return(netparams.GetBTCParams(types.BtcMainnet.String())).AnyTimes()
-	testRelayer := relayer.New(wallet, []byte("bbnt"), btctxformatter.CurrentVersion, submitterAddr, 10)
+	submitterMetrics := metrics.NewSubmitterMetrics()
+	testRelayer := relayer.New(wallet, []byte("bbnt"), btctxformatter.CurrentVersion, submitterAddr,
+		metrics.NewRelayerMetrics(submitterMetrics.Registry), 10)
 
 	// 1. only SegWit Bech32 addresses
 	segWitBech32Addrs := append(SegWitBech32p2wshAddrsStr, SegWitBech32p2wpkhAddrsStr...)

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -117,7 +117,7 @@ func (rl *Relayer) SendCheckpointToBTC(ckpt *ckpttypes.RawCheckpointWithMeta) er
 			strconv.Itoa(int(ckptEpoch)),
 			"1",
 			resubmittedTx2.TxId.String(),
-			fmt.Sprintf("%d Satoshis", resubmittedTx2.Fee),
+			strconv.Itoa(int(resubmittedTx2.Fee)),
 		).SetToCurrentTime()
 		rl.metrics.ResentCheckpointsCounter.Inc()
 
@@ -280,7 +280,7 @@ func (rl *Relayer) convertCkptToTwoTxAndSubmit(ckpt *ckpttypes.RawCheckpointWith
 		strconv.Itoa(int(ckpt.Ckpt.EpochNum)),
 		"1",
 		tx2.Tx.TxHash().String(),
-		fmt.Sprintf("%d Satoshis", tx2.Fee),
+		strconv.Itoa(int(tx2.Fee)),
 	).SetToCurrentTime()
 
 	return &types.CheckpointInfo{

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -108,6 +108,7 @@ func (rl *Relayer) SendCheckpointToBTC(ckpt *ckpttypes.RawCheckpointWithMeta) er
 
 		resubmittedTx2, err := rl.resendSecondTxOfCheckpointToBTC(rl.lastSubmittedCheckpoint.Tx2, bumpedFee)
 		if err != nil {
+			rl.metrics.FailedResentCheckpointsCounter.Inc()
 			return fmt.Errorf("failed to re-send the second tx of the checkpoint %v: %w", rl.lastSubmittedCheckpoint.Epoch, err)
 		}
 
@@ -118,6 +119,7 @@ func (rl *Relayer) SendCheckpointToBTC(ckpt *ckpttypes.RawCheckpointWithMeta) er
 			resubmittedTx2.TxId.String(),
 			fmt.Sprintf("%d Satoshis", resubmittedTx2.Fee),
 		).SetToCurrentTime()
+		rl.metrics.ResentCheckpointsCounter.Inc()
 
 		log.Logger.Infof("Successfully re-sent the second tx of the checkpoint %v, txid: %s, bumped fee: %v Satoshis",
 			rl.lastSubmittedCheckpoint.Epoch, resubmittedTx2.TxId.String(), resubmittedTx2.Fee)

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -15,10 +15,11 @@ import (
 	"github.com/babylonchain/vigilante/metrics"
 	"github.com/babylonchain/vigilante/submitter/relayer"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/babylonchain/vigilante/btcclient"
 	"github.com/babylonchain/vigilante/config"
 	"github.com/babylonchain/vigilante/submitter/poller"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type Submitter struct {
@@ -41,7 +42,8 @@ func New(
 	queryClient query.BabylonQueryClient,
 	submitterAddr sdk.AccAddress,
 	retrySleepTime, maxRetrySleepTime time.Duration,
-	metrics *metrics.SubmitterMetrics) (*Submitter, error) {
+	submitterMetrics *metrics.SubmitterMetrics,
+) (*Submitter, error) {
 	var (
 		btccheckpointParams *btcctypes.QueryParamsResponse
 		err                 error
@@ -67,6 +69,7 @@ func New(
 		checkpointTag,
 		btctxformatter.CurrentVersion,
 		submitterAddr,
+		metrics.NewRelayerMetrics(submitterMetrics.Registry),
 		cfg.ResendIntervalSeconds,
 	)
 
@@ -74,7 +77,7 @@ func New(
 		Cfg:     cfg,
 		poller:  p,
 		relayer: r,
-		metrics: metrics,
+		metrics: submitterMetrics,
 		quit:    make(chan struct{}),
 	}, nil
 }

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -188,7 +188,6 @@ func (s *Submitter) processCheckpoints() {
 				log.Errorf("Failed to submit the raw checkpoint for %v: %v", ckpt.Ckpt.EpochNum, err)
 				s.metrics.FailedCheckpointsCounter.Inc()
 			}
-			s.metrics.SuccessfulCheckpointsCounter.Inc()
 			s.metrics.SecondsSinceLastCheckpointGauge.Set(0)
 		case <-quit:
 			// We have been asked to stop


### PR DESCRIPTION
This PR adds the following Prometheus metrics:

Vigilante submitter: For every submitted transaction export the following. These metrics should be emitted every time a new checkpoint is submitted.
* Tx hashes of checkpoint segments (2)
* Fees for each segment
* Epoch number
* Timestamp
* total available balance sum
* re-send checkpoint interval (emitted when the submitter is first created)
* Number of invalid checkpoints (either epoch or status is invalid) for alerting
* Number of resent checkpoints (triggered if the resend_interval is passed)
* Number of failed resent checkpoints for alerting

Vigilante reporter: For every BTC block export the following. These metrics should be emitted every time a new BTC block / checkpoint is sent to Babylon.
* When a BTC block is submitted
    * BTC block timestamp
* When a BTC checkpoint is submitted
    * Tx hashes of the checkpoint segments
    * The Babylon epoch that it corresponds to
    * BTC block height