### PR TITLE
fix: issue with multiple wallets

### DIFF
--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -27,7 +27,8 @@ func NewWallet(cfg *config.BTCConfig) (*Client, error) {
 	switch cfg.BtcBackend {
 	case types.Bitcoind:
 		connCfg = &rpcclient.ConnConfig{
-			Host:         cfg.Endpoint,
+			// this will work with node loaded with multiple wallets
+			Host:         cfg.Endpoint + "/wallet/" + cfg.WalletName,
 			HTTPPostMode: true,
 			User:         cfg.Username,
 			Pass:         cfg.Password,


### PR DESCRIPTION
An issue reported by @filippos47 when the node loaded with more than wallets, an error would occur to require specifying the wallet name. This PR fixes this issue by specifying the wallet name in `Host`. To @filippos47, please test it before approving this PR. Thanks!