### PR TITLE
feat: Add multiplier for calculating tx fee of resending checkpoints

### DIFF
--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -109,10 +109,11 @@ func (c *Client) GetTxFee(txSize uint64) uint64 {
 			fee, c.Cfg.TxFeeMax)
 		return c.GetMaxTxFee()
 	}
-	if fee < c.Cfg.TxFeeMin.MulF64(float64(txSize)) {
+	minTxFee := c.Cfg.TxFeeMin.MulF64(float64(txSize))
+	if fee < minTxFee {
 		log.Logger.Debugf("the calculated fee %v is lower than MinTxFee %v, using MinTxFee instead",
-			fee, c.Cfg.TxFeeMin)
-		return c.GetMinTxFee() * txSize
+			fee, minTxFee)
+		return uint64(minTxFee)
 	}
 
 	return uint64(fee)

--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -68,7 +68,7 @@ func (c *Client) GetTxFee(txSize uint64) uint64 {
 	)
 
 	// use MaxTxFee by default
-	defaultFee := c.GetMaxTxFee()
+	defaultFee := c.GetMaxTxFee(txSize)
 
 	// if estimatesmartfee is not supported, we use estimatefee instead
 	estimateRes, err := c.Client.EstimateSmartFee(c.Cfg.TargetBlockNum, &btcjson.EstimateModeEconomical)
@@ -104,28 +104,28 @@ func (c *Client) GetTxFee(txSize uint64) uint64 {
 	}
 
 	log.Logger.Debugf("the calculated fee is %v based on its size: %v", fee, txSize)
-	maxTxFee := c.Cfg.TxFeeMax.MulF64(float64(txSize))
+	maxTxFee := c.GetMaxTxFee(txSize)
 	if fee > maxTxFee {
 		log.Logger.Debugf("the calculated fee %v is higher than MaxTxFee %v, using MaxTxFee instead",
 			fee, maxTxFee)
-		return uint64(maxTxFee)
+		return maxTxFee
 	}
-	minTxFee := c.Cfg.TxFeeMin.MulF64(float64(txSize))
+	minTxFee := c.GetMinTxFee(txSize)
 	if fee < minTxFee {
 		log.Logger.Debugf("the calculated fee %v is lower than MinTxFee %v, using MinTxFee instead",
 			fee, minTxFee)
-		return uint64(minTxFee)
+		return minTxFee
 	}
 
-	return uint64(fee)
+	return fee
 }
 
-func (c *Client) GetMaxTxFee() uint64 {
-	return uint64(c.Cfg.TxFeeMax)
+func (c *Client) GetMaxTxFee(size uint64) uint64 {
+	return uint64(c.Cfg.TxFeeMax.MulF64(float64(size)))
 }
 
-func (c *Client) GetMinTxFee() uint64 {
-	return uint64(c.Cfg.TxFeeMin)
+func (c *Client) GetMinTxFee(size uint64) uint64 {
+	return uint64(c.Cfg.TxFeeMin.MulF64(float64(size)))
 }
 
 func (c *Client) GetWalletName() string {
@@ -169,6 +169,6 @@ func (c *Client) DumpPrivKey(address btcutil.Address) (*btcutil.WIF, error) {
 }
 
 // CalculateTxFee calculates tx fee based on the given fee rate (BTC/kB) and the tx size
-func CalculateTxFee(feeRateAmount btcutil.Amount, size uint64) (btcutil.Amount, error) {
-	return feeRateAmount.MulF64(float64(size) / 1024), nil
+func CalculateTxFee(feeRateAmount btcutil.Amount, size uint64) (uint64, error) {
+	return uint64(feeRateAmount.MulF64(float64(size) / 1024)), nil
 }

--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -109,10 +109,10 @@ func (c *Client) GetTxFee(txSize uint64) uint64 {
 			fee, c.Cfg.TxFeeMax)
 		return c.GetMaxTxFee()
 	}
-	if fee < c.Cfg.TxFeeMin {
+	if fee < c.Cfg.TxFeeMin.MulF64(float64(txSize)) {
 		log.Logger.Debugf("the calculated fee %v is lower than MinTxFee %v, using MinTxFee instead",
 			fee, c.Cfg.TxFeeMin)
-		return c.GetMinTxFee()
+		return c.GetMinTxFee() * txSize
 	}
 
 	return uint64(fee)

--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -104,10 +104,11 @@ func (c *Client) GetTxFee(txSize uint64) uint64 {
 	}
 
 	log.Logger.Debugf("the calculated fee is %v based on its size: %v", fee, txSize)
-	if fee > c.Cfg.TxFeeMax {
+	maxTxFee := c.Cfg.TxFeeMax.MulF64(float64(txSize))
+	if fee > maxTxFee {
 		log.Logger.Debugf("the calculated fee %v is higher than MaxTxFee %v, using MaxTxFee instead",
-			fee, c.Cfg.TxFeeMax)
-		return c.GetMaxTxFee()
+			fee, maxTxFee)
+		return uint64(maxTxFee)
 	}
 	minTxFee := c.Cfg.TxFeeMin.MulF64(float64(txSize))
 	if fee < minTxFee {

--- a/btcclient/interface.go
+++ b/btcclient/interface.go
@@ -27,9 +27,9 @@ type BTCWallet interface {
 	GetWalletPass() string
 	GetWalletLockTime() int64
 	GetNetParams() *chaincfg.Params
-	GetTxFee(txSize uint64) uint64 // in the unit of satoshi
-	GetMaxTxFee() uint64           // in the unit of satoshi
-	GetMinTxFee() uint64           // in the unit of satoshi
+	GetTxFee(txSize uint64) uint64    // in the unit of satoshi
+	GetMaxTxFee(txSize uint64) uint64 // in the unit of satoshi
+	GetMinTxFee(txSize uint64) uint64 // in the unit of satoshi
 	ListUnspent() ([]btcjson.ListUnspentResult, error)
 	ListReceivedByAddress() ([]btcjson.ListReceivedByAddressResult, error)
 	SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error)

--- a/config/bitcoin.go
+++ b/config/bitcoin.go
@@ -18,8 +18,8 @@ type BTCConfig struct {
 	WalletName        string                    `mapstructure:"wallet-name"`
 	WalletCAFile      string                    `mapstructure:"wallet-ca-file"`
 	WalletLockTime    int64                     `mapstructure:"wallet-lock-time"` // time duration in which the wallet remains unlocked, in seconds
-	TxFeeMin          btcutil.Amount            `mapstructure:"tx-fee-min"`       // minimum tx fee per byte, in Satoshi
-	TxFeeMax          btcutil.Amount            `mapstructure:"tx-fee-max"`       // maximum tx fee per byte, in Satoshi
+	TxFeeMin          btcutil.Amount            `mapstructure:"tx-fee-min"`       // minimum tx fee, sat/byte
+	TxFeeMax          btcutil.Amount            `mapstructure:"tx-fee-max"`       // maximum tx fee, sat/byte
 	TargetBlockNum    int64                     `mapstructure:"target-block-num"` // this implies how soon the tx is estimated to be included in a block, e.g., 1 means the tx is estimated to be included in the next block
 	NetParams         string                    `mapstructure:"net-params"`
 	Username          string                    `mapstructure:"username"`
@@ -71,8 +71,8 @@ func DefaultBTCConfig() BTCConfig {
 		WalletName:        "default",
 		WalletCAFile:      defaultBtcWalletCAFile,
 		WalletLockTime:    10,
-		TxFeeMin:          btcutil.Amount(5),   // minimum tx fee per byte in satoshi
-		TxFeeMax:          btcutil.Amount(100), // maximum tx fee per byte in satoshi
+		TxFeeMin:          btcutil.Amount(5),   // minimum tx fee, sat/byte
+		TxFeeMax:          btcutil.Amount(100), // maximum tx fee, sat/byte
 		TargetBlockNum:    1,
 		NetParams:         types.BtcSimnet.String(),
 		Username:          "rpcuser",

--- a/config/bitcoin.go
+++ b/config/bitcoin.go
@@ -19,7 +19,7 @@ type BTCConfig struct {
 	WalletCAFile      string                    `mapstructure:"wallet-ca-file"`
 	WalletLockTime    int64                     `mapstructure:"wallet-lock-time"` // time duration in which the wallet remains unlocked, in seconds
 	TxFeeMin          btcutil.Amount            `mapstructure:"tx-fee-min"`       // minimum tx fee per byte, in Satoshi
-	TxFeeMax          btcutil.Amount            `mapstructure:"tx-fee-max"`       // maximum tx fee, in Satoshi
+	TxFeeMax          btcutil.Amount            `mapstructure:"tx-fee-max"`       // maximum tx fee per byte, in Satoshi
 	TargetBlockNum    int64                     `mapstructure:"target-block-num"` // this implies how soon the tx is estimated to be included in a block, e.g., 1 means the tx is estimated to be included in the next block
 	NetParams         string                    `mapstructure:"net-params"`
 	Username          string                    `mapstructure:"username"`
@@ -71,8 +71,8 @@ func DefaultBTCConfig() BTCConfig {
 		WalletName:        "default",
 		WalletCAFile:      defaultBtcWalletCAFile,
 		WalletLockTime:    10,
-		TxFeeMin:          btcutil.Amount(5),     // minimum tx fee per byte in satoshi
-		TxFeeMax:          btcutil.Amount(10000), // maximum tx fee
+		TxFeeMin:          btcutil.Amount(5),   // minimum tx fee per byte in satoshi
+		TxFeeMax:          btcutil.Amount(100), // maximum tx fee per byte in satoshi
 		TargetBlockNum:    1,
 		NetParams:         types.BtcSimnet.String(),
 		Username:          "rpcuser",

--- a/config/bitcoin.go
+++ b/config/bitcoin.go
@@ -71,8 +71,8 @@ func DefaultBTCConfig() BTCConfig {
 		WalletName:        "default",
 		WalletCAFile:      defaultBtcWalletCAFile,
 		WalletLockTime:    10,
-		TxFeeMin:          btcutil.Amount(5),   // minimum tx fee, sat/byte
-		TxFeeMax:          btcutil.Amount(100), // maximum tx fee, sat/byte
+		TxFeeMin:          btcutil.Amount(1),  // minimum tx fee, sat/byte
+		TxFeeMax:          btcutil.Amount(20), // maximum tx fee, sat/byte
 		TargetBlockNum:    1,
 		NetParams:         types.BtcSimnet.String(),
 		Username:          "rpcuser",

--- a/config/bitcoin.go
+++ b/config/bitcoin.go
@@ -18,8 +18,8 @@ type BTCConfig struct {
 	WalletName        string                    `mapstructure:"wallet-name"`
 	WalletCAFile      string                    `mapstructure:"wallet-ca-file"`
 	WalletLockTime    int64                     `mapstructure:"wallet-lock-time"` // time duration in which the wallet remains unlocked, in seconds
-	TxFeeMin          btcutil.Amount            `mapstructure:"tx-fee-min"`       // minimum tx fee, in BTC
-	TxFeeMax          btcutil.Amount            `mapstructure:"tx-fee-max"`       // maximum tx fee, in BTC
+	TxFeeMin          btcutil.Amount            `mapstructure:"tx-fee-min"`       // minimum tx fee per byte, in Satoshi
+	TxFeeMax          btcutil.Amount            `mapstructure:"tx-fee-max"`       // maximum tx fee, in Satoshi
 	TargetBlockNum    int64                     `mapstructure:"target-block-num"` // this implies how soon the tx is estimated to be included in a block, e.g., 1 means the tx is estimated to be included in the next block
 	NetParams         string                    `mapstructure:"net-params"`
 	Username          string                    `mapstructure:"username"`
@@ -61,8 +61,6 @@ func (cfg *BTCConfig) Validate() error {
 }
 
 func DefaultBTCConfig() BTCConfig {
-	feeAmountMin := btcutil.Amount(1000)
-	feeAmountMax := btcutil.Amount(10000)
 
 	return BTCConfig{
 		DisableClientTLS:  false,
@@ -73,8 +71,8 @@ func DefaultBTCConfig() BTCConfig {
 		WalletName:        "default",
 		WalletCAFile:      defaultBtcWalletCAFile,
 		WalletLockTime:    10,
-		TxFeeMin:          feeAmountMin,
-		TxFeeMax:          feeAmountMax,
+		TxFeeMin:          btcutil.Amount(5),     // minimum tx fee per byte in satoshi
+		TxFeeMax:          btcutil.Amount(10000), // maximum tx fee
 		TargetBlockNum:    1,
 		NetParams:         types.BtcSimnet.String(),
 		Username:          "rpcuser",

--- a/config/submitter.go
+++ b/config/submitter.go
@@ -10,7 +10,7 @@ const (
 	DefaultCheckpointCacheMaxEntries = 100
 	DefaultPollingIntervalSeconds    = 60   // in seconds
 	DefaultResendIntervalSeconds     = 1800 // 30 minutes
-	DefaultResubmitFeeMultiplier     = 1.1
+	DefaultResubmitFeeMultiplier     = 1
 )
 
 // SubmitterConfig defines configuration for the gRPC-web server.
@@ -19,7 +19,7 @@ type SubmitterConfig struct {
 	NetParams string `mapstructure:"netparams"`
 	// BufferSize defines the number of raw checkpoints stored in the buffer
 	BufferSize uint `mapstructure:"buffer-size"`
-	// ResubmitFeeMultiplier is used to multiply the estimated the bumped fee in resubmission
+	// ResubmitFeeMultiplier is used to multiply the estimated bumped fee in resubmission
 	ResubmitFeeMultiplier float64 `mapstructure:"resubmit-fee-multiplier"`
 	// PollingIntervalSeconds defines the intervals (in seconds) between each polling of Babylon checkpoints
 	PollingIntervalSeconds uint `mapstructure:"polling-interval-seconds"`
@@ -33,8 +33,8 @@ func (cfg *SubmitterConfig) Validate() error {
 		return errors.New("invalid net params")
 	}
 
-	if cfg.ResubmitFeeMultiplier <= 0 {
-		return errors.New("invalid resubmit-fee-multiplier, should be more than 0")
+	if cfg.ResubmitFeeMultiplier < 1 {
+		return errors.New("invalid resubmit-fee-multiplier, should not be less than 1")
 	}
 
 	return nil

--- a/config/submitter.go
+++ b/config/submitter.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/babylonchain/vigilante/types"
 )
 
@@ -9,20 +10,33 @@ const (
 	DefaultCheckpointCacheMaxEntries = 100
 	DefaultPollingIntervalSeconds    = 60   // in seconds
 	DefaultResendIntervalSeconds     = 1800 // 30 minutes
+	DefaultResubmitFeeMultiplier     = 1.1
 )
 
 // SubmitterConfig defines configuration for the gRPC-web server.
 type SubmitterConfig struct {
-	NetParams              string `mapstructure:"netparams"`   // should be mainnet|testnet|simnet|signet
-	BufferSize             uint   `mapstructure:"buffer-size"` // buffer for raw checkpoints
-	PollingIntervalSeconds uint   `mapstructure:"polling-interval-seconds"`
-	ResendIntervalSeconds  uint   `mapstructure:"resend-interval-seconds"`
+	// NetParams defines the BTC network params, which should be mainnet|testnet|simnet|signet
+	NetParams string `mapstructure:"netparams"`
+	// BufferSize defines the number of raw checkpoints stored in the buffer
+	BufferSize uint `mapstructure:"buffer-size"`
+	// ResubmitFeeMultiplier is used to multiply the estimated the bumped fee in resubmission
+	ResubmitFeeMultiplier float64 `mapstructure:"resubmit-fee-multiplier"`
+	// PollingIntervalSeconds defines the intervals (in seconds) between each polling of Babylon checkpoints
+	PollingIntervalSeconds uint `mapstructure:"polling-interval-seconds"`
+	// ResendIntervalSeconds defines the time (in seconds) which the submitter awaits
+	// before resubmitting checkpoints to BTC
+	ResendIntervalSeconds uint `mapstructure:"resend-interval-seconds"`
 }
 
 func (cfg *SubmitterConfig) Validate() error {
 	if _, ok := types.GetValidNetParams()[cfg.NetParams]; !ok {
 		return errors.New("invalid net params")
 	}
+
+	if cfg.ResubmitFeeMultiplier <= 0 {
+		return errors.New("invalid resubmit-fee-multiplier, should be more than 0")
+	}
+
 	return nil
 }
 
@@ -30,6 +44,7 @@ func DefaultSubmitterConfig() SubmitterConfig {
 	return SubmitterConfig{
 		NetParams:              types.BtcSimnet.String(),
 		BufferSize:             DefaultCheckpointCacheMaxEntries,
+		ResubmitFeeMultiplier:  DefaultResubmitFeeMultiplier,
 		PollingIntervalSeconds: DefaultPollingIntervalSeconds,
 		ResendIntervalSeconds:  DefaultResendIntervalSeconds,
 	}

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -416,6 +416,7 @@ func TestSubmitterSubmissionReplace(t *testing.T) {
 
 	tm.Config.Submitter.PollingIntervalSeconds = 2
 	tm.Config.Submitter.ResendIntervalSeconds = 2
+	tm.Config.Submitter.ResubmitFeeMultiplier = 2
 	// create submitter
 	vigilantSubmitter, _ := submitter.New(
 		&tm.Config.Submitter,

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -416,7 +416,7 @@ func TestSubmitterSubmissionReplace(t *testing.T) {
 
 	tm.Config.Submitter.PollingIntervalSeconds = 2
 	tm.Config.Submitter.ResendIntervalSeconds = 2
-	tm.Config.Submitter.ResubmitFeeMultiplier = 2
+	tm.Config.Submitter.ResubmitFeeMultiplier = 2.1
 	// create submitter
 	vigilantSubmitter, _ := submitter.New(
 		&tm.Config.Submitter,

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -443,9 +443,6 @@ func TestSubmitterSubmissionReplace(t *testing.T) {
 		return len(submittedTransactions) == 2
 	}, eventuallyWaitTimeOut, eventuallyPollTime)
 
-	// hack: tune the TxFeeMin to make sure the resending is triggered
-	tm.BtcWalletClient.Cfg.TxFeeMin = btcutil.Amount(10000)
-
 	sendTransactions := retrieveTransactionFromMempool(t, tm.MinerNode, submittedTransactions)
 
 	// at this point our submitter already sent 2 checkpoint transactions which landed in mempool.

--- a/sample-vigilante-docker.yml
+++ b/sample-vigilante-docker.yml
@@ -49,7 +49,7 @@ metrics:
 submitter:
   netparams: simnet
   buffer-size: 100
-  resubmit-fee-multiplier: 1.1
+  resubmit-fee-multiplier: 1
   polling-interval-seconds: 60
   resend-interval-seconds: 1800
 reporter:

--- a/sample-vigilante-docker.yml
+++ b/sample-vigilante-docker.yml
@@ -49,6 +49,7 @@ metrics:
 submitter:
   netparams: simnet
   buffer-size: 100
+  resubmit-fee-multiplier: 1.1
   polling-interval-seconds: 60
   resend-interval-seconds: 1800
 reporter:

--- a/sample-vigilante-docker.yml
+++ b/sample-vigilante-docker.yml
@@ -5,8 +5,8 @@ btc:
   no-client-tls: true   # use true for bitcoind as it does not support tls
   ca-file: ~
   endpoint: bitcoindsim:18443  # use port 18443 for bitcoind regtest
-  tx-fee-min: 1000
-  tx-fee-max: 100000
+  tx-fee-min: 5 # minimum tx fee, sat/byte
+  tx-fee-max: 100 # maximum tx fee, sat/byte
   target-block-num: 2
   wallet-endpoint: ~
   wallet-password: walletpass

--- a/sample-vigilante-docker.yml
+++ b/sample-vigilante-docker.yml
@@ -5,8 +5,8 @@ btc:
   no-client-tls: true   # use true for bitcoind as it does not support tls
   ca-file: ~
   endpoint: bitcoindsim:18443  # use port 18443 for bitcoind regtest
-  tx-fee-min: 5 # minimum tx fee, sat/byte
-  tx-fee-max: 100 # maximum tx fee, sat/byte
+  tx-fee-min: 1 # minimum tx fee, sat/byte
+  tx-fee-max: 20 # maximum tx fee, sat/byte
   target-block-num: 2
   wallet-endpoint: ~
   wallet-password: walletpass

--- a/sample-vigilante.yml
+++ b/sample-vigilante.yml
@@ -49,7 +49,7 @@ metrics:
 submitter:
   netparams: simnet
   buffer-size: 10
-  resubmit-fee-multiplier: 1.1
+  resubmit-fee-multiplier: 1
   polling-interval-seconds: 60
   resend-interval-seconds: 1800
 reporter:

--- a/sample-vigilante.yml
+++ b/sample-vigilante.yml
@@ -5,8 +5,8 @@ btc:
   no-client-tls: false # use true for bitcoind as it does not support tls
   ca-file: $TESTNET_PATH/bitcoin/rpc.cert
   endpoint: localhost:18556 # use port 18443 for bitcoind regtest
-  tx-fee-min: 1000
-  tx-fee-max: 100000
+  tx-fee-min: 5 # minimum tx fee, sat/byte
+  tx-fee-max: 100 # maximum tx fee, sat/byte
   target-block-num: 2
   wallet-endpoint: localhost:18554
   wallet-password: walletpass

--- a/sample-vigilante.yml
+++ b/sample-vigilante.yml
@@ -5,8 +5,8 @@ btc:
   no-client-tls: false # use true for bitcoind as it does not support tls
   ca-file: $TESTNET_PATH/bitcoin/rpc.cert
   endpoint: localhost:18556 # use port 18443 for bitcoind regtest
-  tx-fee-min: 5 # minimum tx fee, sat/byte
-  tx-fee-max: 100 # maximum tx fee, sat/byte
+  tx-fee-min: 1 # minimum tx fee, sat/byte
+  tx-fee-max: 20 # maximum tx fee, sat/byte
   target-block-num: 2
   wallet-endpoint: localhost:18554
   wallet-password: walletpass

--- a/sample-vigilante.yml
+++ b/sample-vigilante.yml
@@ -49,6 +49,7 @@ metrics:
 submitter:
   netparams: simnet
   buffer-size: 10
+  resubmit-fee-multiplier: 1.1
   polling-interval-seconds: 60
   resend-interval-seconds: 1800
 reporter:

--- a/submitter/relayer/change_address_test.go
+++ b/submitter/relayer/change_address_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/babylonchain/babylon/btctxformatter"
 
+	"github.com/babylonchain/vigilante/config"
 	"github.com/babylonchain/vigilante/metrics"
 	"github.com/babylonchain/vigilante/netparams"
 	"github.com/babylonchain/vigilante/submitter/relayer"
@@ -42,8 +43,9 @@ func TestGetChangeAddress(t *testing.T) {
 	wallet := mocks.NewMockBTCWallet(gomock.NewController(t))
 	wallet.EXPECT().GetNetParams().Return(netparams.GetBTCParams(types.BtcMainnet.String())).AnyTimes()
 	submitterMetrics := metrics.NewSubmitterMetrics()
+	cfg := config.DefaultSubmitterConfig()
 	testRelayer := relayer.New(wallet, []byte("bbnt"), btctxformatter.CurrentVersion, submitterAddr,
-		metrics.NewRelayerMetrics(submitterMetrics.Registry), 10)
+		metrics.NewRelayerMetrics(submitterMetrics.Registry), &cfg)
 
 	// 1. only SegWit Bech32 addresses
 	segWitBech32Addrs := append(SegWitBech32p2wshAddrsStr, SegWitBech32p2wpkhAddrsStr...)

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -193,7 +193,7 @@ func (rl *Relayer) calcMinRequiredTxReplacementFee(serializedSize uint64) uint64
 	// Calculate the minimum fee for a transaction to be allowed into the
 	// mempool and relayed by scaling the base fee (which is the minimum
 	// free transaction relay fee).
-	minFee := serializedSize * rl.GetMinTxFee()
+	minFee := rl.GetMinTxFee(serializedSize)
 
 	// Set the minimum fee to the maximum possible value if the calculated
 	// fee is not in the valid range for monetary amounts.
@@ -381,11 +381,6 @@ func (rl *Relayer) PickHighUTXO() (*types.UTXO, error) {
 	amount, err := btcutil.NewAmount(topUtxo.Amount)
 	if err != nil {
 		panic(err)
-	}
-
-	// TODO: consider dust, reference: https://www.oreilly.com/library/view/mastering-bitcoin/9781491902639/ch08.html#tx_verification
-	if uint64(amount.ToUnit(btcutil.AmountSatoshi)) < rl.GetMaxTxFee()*2 {
-		return nil, errors.New("insufficient fees")
 	}
 
 	log.Logger.Debugf("pick utxo with id: %v, amount: %v, confirmations: %v", topUtxo.TxID, topUtxo.Amount, topUtxo.Confirmations)

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -145,11 +145,17 @@ func (rl *Relayer) shouldResendCheckpoint(ckptInfo *types.CheckpointInfo, bumped
 
 // calculateBumpedFee calculates the bumped fees of the second tx of the checkpoint
 // based on the current BTC load, considering both tx sizes
+// for BTC network other than the mainnet, we simply double the fee because
+// the estimation for these networks is not accurate
 func (rl *Relayer) calculateBumpedFee(ckptInfo *types.CheckpointInfo) uint64 {
-	tx1Size := ckptInfo.Tx1.Size
-	tx2Size := ckptInfo.Tx2.Size
-	// minus the old fee of the first transaction because we do not want to pay again for the first transaction
-	return rl.GetTxFee(tx1Size) + rl.GetTxFee(tx2Size) - ckptInfo.Tx1.Fee
+	if rl.BTCWallet.GetNetParams().Name == types.BtcMainnet.String() {
+		tx1Size := ckptInfo.Tx1.Size
+		tx2Size := ckptInfo.Tx2.Size
+		// minus the old fee of the first transaction because we do not want to pay again for the first transaction
+		return rl.GetTxFee(tx1Size) + rl.GetTxFee(tx2Size) - ckptInfo.Tx1.Fee
+	} else {
+		return ckptInfo.Tx2.Fee * 2
+	}
 }
 
 // resendSecondTxOfCheckpointToBTC resends the second tx of the checkpoint with bumpedFee

--- a/submitter/relayer/relayer.go
+++ b/submitter/relayer/relayer.go
@@ -192,10 +192,8 @@ func (rl *Relayer) resendSecondTxOfCheckpointToBTC(tx2 *types.BtcTxInfo, bumpedF
 func (rl *Relayer) calcMinRequiredTxReplacementFee(serializedSize uint64) uint64 {
 	// Calculate the minimum fee for a transaction to be allowed into the
 	// mempool and relayed by scaling the base fee (which is the minimum
-	// free transaction relay fee).  minRelayTxFee is in Satoshi/kB so
-	// multiply by serializedSize (which is in bytes) and divide by 1000 to
-	// get minimum Satoshis.
-	minFee := (serializedSize * rl.GetMinTxFee()) / 1000
+	// free transaction relay fee).
+	minFee := serializedSize * rl.GetMinTxFee()
 
 	// Set the minimum fee to the maximum possible value if the calculated
 	// fee is not in the valid range for monetary amounts.

--- a/submitter/submitter.go
+++ b/submitter/submitter.go
@@ -64,12 +64,13 @@ func New(
 
 	p := poller.New(queryClient, cfg.BufferSize)
 
-	r := relayer.New(btcWallet,
+	r := relayer.New(
+		btcWallet,
 		checkpointTag,
 		btctxformatter.CurrentVersion,
 		submitterAddr,
 		metrics.NewRelayerMetrics(submitterMetrics.Registry),
-		cfg.ResendIntervalSeconds,
+		cfg,
 	)
 
 	return &Submitter{

--- a/testutil/mocks/btcclient.go
+++ b/testutil/mocks/btcclient.go
@@ -9,10 +9,10 @@ import (
 
 	types "github.com/babylonchain/vigilante/types"
 	btcjson "github.com/btcsuite/btcd/btcjson"
+	btcutil "github.com/btcsuite/btcd/btcutil"
 	chaincfg "github.com/btcsuite/btcd/chaincfg"
 	chainhash "github.com/btcsuite/btcd/chaincfg/chainhash"
 	wire "github.com/btcsuite/btcd/wire"
-	btcutil "github.com/btcsuite/btcd/btcutil"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -191,31 +191,31 @@ func (mr *MockBTCWalletMockRecorder) DumpPrivKey(address interface{}) *gomock.Ca
 }
 
 // GetMaxTxFee mocks base method.
-func (m *MockBTCWallet) GetMaxTxFee() uint64 {
+func (m *MockBTCWallet) GetMaxTxFee(txSize uint64) uint64 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMaxTxFee")
+	ret := m.ctrl.Call(m, "GetMaxTxFee", txSize)
 	ret0, _ := ret[0].(uint64)
 	return ret0
 }
 
 // GetMaxTxFee indicates an expected call of GetMaxTxFee.
-func (mr *MockBTCWalletMockRecorder) GetMaxTxFee() *gomock.Call {
+func (mr *MockBTCWalletMockRecorder) GetMaxTxFee(txSize interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxTxFee", reflect.TypeOf((*MockBTCWallet)(nil).GetMaxTxFee))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxTxFee", reflect.TypeOf((*MockBTCWallet)(nil).GetMaxTxFee), txSize)
 }
 
 // GetMinTxFee mocks base method.
-func (m *MockBTCWallet) GetMinTxFee() uint64 {
+func (m *MockBTCWallet) GetMinTxFee(txSize uint64) uint64 {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMinTxFee")
+	ret := m.ctrl.Call(m, "GetMinTxFee", txSize)
 	ret0, _ := ret[0].(uint64)
 	return ret0
 }
 
 // GetMinTxFee indicates an expected call of GetMinTxFee.
-func (mr *MockBTCWalletMockRecorder) GetMinTxFee() *gomock.Call {
+func (mr *MockBTCWalletMockRecorder) GetMinTxFee(txSize interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinTxFee", reflect.TypeOf((*MockBTCWallet)(nil).GetMinTxFee))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinTxFee", reflect.TypeOf((*MockBTCWallet)(nil).GetMinTxFee), txSize)
 }
 
 // GetNetParams mocks base method.


### PR DESCRIPTION
This PR adds a new bumping fee method by simply doubling the previous fee for testing the rbf feature. This is needed for testing the feature in BTC networks other than the mainnet because the estimation of fees in these networks is not accurate.