### PR TITLE
fix: fix tx virtual size calculation and minimum relay fee

### DIFF
--- a/btcclient/client.go
+++ b/btcclient/client.go
@@ -7,14 +7,16 @@ package btcclient
 
 import (
 	"fmt"
-	"github.com/btcsuite/btcd/btcjson"
 	"time"
+
+	"github.com/btcsuite/btcd/btcjson"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/rpcclient"
 
 	"github.com/babylonchain/vigilante/config"
 	"github.com/babylonchain/vigilante/types"
 	"github.com/babylonchain/vigilante/zmq"
-	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcd/rpcclient"
 )
 
 var _ BTCClient = &Client{}

--- a/btcclient/client_wallet.go
+++ b/btcclient/client_wallet.go
@@ -144,7 +144,7 @@ func (c *Client) GetMinTxFee(size uint64) uint64 {
 
 	// Set the minimum fee to the maximum possible value if the calculated
 	// fee is not in the valid range for monetary amounts.
-	if minFee < 0 || minFee > btcutil.MaxSatoshi {
+	if minFee > btcutil.MaxSatoshi {
 		minFee = btcutil.MaxSatoshi
 	}
 

--- a/btcclient/interface.go
+++ b/btcclient/interface.go
@@ -36,4 +36,5 @@ type BTCWallet interface {
 	GetRawChangeAddress(account string) (btcutil.Address, error)
 	WalletPassphrase(passphrase string, timeoutSecs int64) error
 	DumpPrivKey(address btcutil.Address) (*btcutil.WIF, error)
+	GetMinRelayFee() (uint64, error) // in the unit of sat/byte
 }

--- a/e2etest/e2e_test.go
+++ b/e2etest/e2e_test.go
@@ -60,7 +60,7 @@ var (
 	exisitngWalletPass = "pass"
 	walletTimeout      = 86400
 
-	eventuallyWaitTimeOut = 10 * time.Second
+	eventuallyWaitTimeOut = 20 * time.Second
 	eventuallyPollTime    = 500 * time.Millisecond
 )
 

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/ChainSafe/go-schnorrkel v0.0.0-20200405005733-88cbf1b4c40d // indirect
 	github.com/CosmWasm/wasmd v0.40.0-rc.2 // indirect
 	github.com/CosmWasm/wasmvm v1.2.3 // indirect
+	github.com/aead/siphash v1.0.1 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/avast/retry-go/v4 v4.3.3 // indirect
 	github.com/aws/aws-sdk-go v1.44.203 // indirect
@@ -130,6 +131,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d // indirect
+	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 // indirect
 	github.com/klauspost/compress v1.16.3 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/libp2p/go-buffer-pool v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,7 @@ github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrd
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/Zilliqa/gozilliqa-sdk v1.2.1-0.20201201074141-dd0ecada1be6/go.mod h1:eSYp2T6f0apnuW8TzhV3f6Aff2SE8Dwio++U4ha4yEM=
 github.com/adlio/schema v1.3.3 h1:oBJn8I02PyTB466pZO1UZEn1TV5XLlifBSyMrmHl/1I=
+github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -844,6 +845,7 @@ github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d h1:Z+RDyXzjKE0
 github.com/keybase/go-keychain v0.0.0-20190712205309-48d3d31d256d/go.mod h1:JJNrCn9otv/2QP4D7SMJBgaleKpOf66PnW6F5WGNRIc=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=

--- a/testutil/mocks/btcclient.go
+++ b/testutil/mocks/btcclient.go
@@ -204,6 +204,21 @@ func (mr *MockBTCWalletMockRecorder) GetMaxTxFee(txSize interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxTxFee", reflect.TypeOf((*MockBTCWallet)(nil).GetMaxTxFee), txSize)
 }
 
+// GetMinRelayFee mocks base method.
+func (m *MockBTCWallet) GetMinRelayFee() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMinRelayFee")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMinRelayFee indicates an expected call of GetMinRelayFee.
+func (mr *MockBTCWalletMockRecorder) GetMinRelayFee() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMinRelayFee", reflect.TypeOf((*MockBTCWallet)(nil).GetMinRelayFee))
+}
+
 // GetMinTxFee mocks base method.
 func (m *MockBTCWallet) GetMinTxFee(txSize uint64) uint64 {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR fixes a corner case where the estimation is lower than the minimum required relay fee and the tx is rejected by the mempool. In particular, this PR:
1. replaced the current calculation of tx size with [GetTxVirtualSize](https://github.com/btcsuite/btcd/blob/d776d9c105ae38aa585f1573233561b882ac7f6a/mempool/mempool.go#L1148)
2. ensures the `tx-fee-min` is higher than the minimum relay fee obtained from Bitcoin