### PR TITLE
doc: documentation for BTC staking tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ Vigilante program for Babylon
 
 - Go 1.21
 - Package [libzmq](https://github.com/zeromq/libzmq)
-
-### Testing requirements
-
-- [btcd](https://github.com/btcsuite/btcd/tree/master?tab=readme-ov-file#installation) bins
+- (for testing) [btcd](https://github.com/btcsuite/btcd/tree/master?tab=readme-ov-file#installation) binaries
 
 ## Building
 
 In order to build the vigilante,
+
 ```shell
 make build
 ```
@@ -21,6 +19,7 @@ make build
 ## Running the vigilante
 
 For the following:
+
 ```shell
 BABYLON_PATH="path_where_babylon_is_built" # example: $HOME/Projects/Babylon/babylon
 VIGILANTE_PATH="root_vigilante_dir" # example: $HOME/Projects/Babylon/vigilante
@@ -43,6 +42,7 @@ $BABYLON_PATH/build/babylond testnet \
 ```
 
 Using this configuration, start the testnet for the single node.
+
 ```shell
 $BABYLON_PATH/build/babylond start --home $TESTNET_PATH/node0/babylond
 ```
@@ -100,6 +100,7 @@ Leave this process running.
 Then, create a simnet Bitcoin wallet.
 If you want to use the default vigilante file, then give the password `walletpass`.
 Otherwise, make sure to edit the `vigilante.yaml` to reflect the correct password.
+
 ```shell
 btcwallet --simnet -u rpcuser -P rpcpass \
           --rpccert $TESTNET_PATH/bitcoin/rpc-wallet.cert --rpckey $TESTNET_PATH/bitcoin/rpc-wallet.key \
@@ -111,15 +112,18 @@ The above instruction is going to prompt you for a password and going to give yo
 Store those securely.
 
 Afterwards, start the wallet service listening to port `18554`:
+
 ```shell
 btcwallet --simnet -u rpcuser -P rpcpass --rpclisten=127.0.0.1:18554 \
           --rpccert $TESTNET_PATH/bitcoin/rpc-wallet.cert --rpckey $TESTNET_PATH/bitcoin/rpc-wallet.key \
           --cafile $TESTNET_PATH/bitcoin/rpc.cert
 ```
+
 Leave this process running. If you get an error that a wallet already exists and you still want
 to create one, delete the `wallet.db` file located in the path displayed by the error message.
 
 Create an address that will be later used for mining. The output below is a sample one.
+
 ```shell
 $ btcctl --simnet --wallet -u rpcuser -P rpcpass \
        --rpccert $TESTNET_PATH/bitcoin/rpc-wallet.cert \
@@ -130,24 +134,27 @@ SQqHYFTSPh8WAyJvzbAC8hoLbF12UVsE5s
 
 Finally, restart the btcd service with the new address.
 First, kill the `btcd` process that you started in the first step, and then:
-```sh
+
+```shell
 btcd --simnet --rpclisten 127.0.0.1:18556 --rpcuser rpcuser --rpcpass rpcpass \
     --rpccert $TESTNET_PATH/bitcoin/rpc.cert --rpckey $TESTNET_PATH/bitcoin/rpc.key \
     --miningaddr $MINING_ADDRESS
 ```
-where `$MINING_ADDRESS` is the address that you got as an output in the previous command.
 
+where `$MINING_ADDRESS` is the address that you got as an output in the previous command.
 
 #### Generating BTC blocks
 
 While running this setup, one might want to generate BTC blocks.
 We accomplish that through the btcd `btcctl` utility and the use
 of the parameters we defined above.
+
 ```shell
 btcctl --simnet --wallet --rpcuser=rpcuser --rpcpass=rpcpass \
        --rpccert=$TESTNET_PATH/bitcoin/rpc-wallet.cert \
        generate $NUM_BLOCKS
 ```
+
 where `$NUM_BLOCKS` is the number of blocks you want to generate.
 
 Not that in order to spend the mining rewards, at least 100 blocks should be
@@ -174,6 +181,7 @@ mkdir $TESTNET_PATH/vigilante
 #### Running the vigilante reporter
 
 Initially, copy the sample configuration
+
 ```shell
 cp sample-vigilante.yml $TESTNET_PATH/vigilante/vigilante.yml
 nano $TESTNET_PATH/vigilante/vigilante.yml # edit the config file to replace $TESTNET instances
@@ -206,9 +214,10 @@ go run $VIGILANTE_PATH/cmd/main.go monitor \
 
 ### Running the vigilante using Docker
 
-#### Running the vigilante reporter
+#### Running the vigilante reporter in Docker container
 
 Initially, build a Docker image named `babylonchain/vigilante-reporter`
+
 ```shell
 cp sample-vigilante-docker.yml $TESTNET_PATH/vigilante/vigilante.yml
 make reporter-build
@@ -225,9 +234,10 @@ docker run --rm \
          babylonchain/vigilante-reporter
 ```
 
-#### Running the vigilante submitter
+#### Running the vigilante submitter in Docker container
 
 Follow the same steps as above, but with the `babylonchain/vigilante-submitter` Docker image.
+
 ```shell
 docker run --rm \
          -v $TESTNET_PATH/bitcoin:/bitcoin \
@@ -236,9 +246,10 @@ docker run --rm \
          babylonchain/vigilante-submitter
 ```
 
-#### Running the vigilante monitor
+#### Running the vigilante monitor in Docker container
 
 Follow the same steps as above, but with the `babylonchain/vigilante-monitor` Docker image.
+
 ```shell
 docker run --rm \
          -v $TESTNET_PATH/bitcoin:/bitcoin \

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # vigilante
 
-Vigilante program for Babylon
+This repository contains vigilante programs for Babylon. They are daemon programs that relay information between Babylon and Bitcoin for facilitating the Bitcoin timestamping protocol and the Bitcoin staking protocol.
+
+There are four vigilante programs:
+
+- [Submitter](./submitter/README.md): submitting Babylon checkpoints to Bitcoin.
+- [Reporter](./reporter/README.md): reporting Bitcoin headers and Babylon checkpoints to Babylon.
+- [BTC timestamping monitor](./monitor/README.md): monitoring censorship of Babylon checkpoints in Babylon.
+- [BTC staking tracker](./btcstaking-tracker/README.md): monitoring early unbonding of BTC delegations and slashing adversarial finality providers.
 
 ## Requirements
 
 - Go 1.21
 - Package [libzmq](https://github.com/zeromq/libzmq)
-- (for testing) [btcd](https://github.com/btcsuite/btcd/tree/master?tab=readme-ov-file#installation) binaries
+- [btcd](https://github.com/btcsuite/btcd/tree/master?tab=readme-ov-file#installation) binaries (only for testing)
 
 ## Building
 
@@ -212,6 +219,17 @@ go run $VIGILANTE_PATH/cmd/main.go monitor \
          --config $TESTNET_PATH/vigilante/vigilante.yml
 ```
 
+#### Running the BTC staking tracker
+
+We first need to ensure that a BTC full node and the Babylon node that we want to monitor are started running.
+
+Then we start the BTC staking tracker:
+
+```shell
+go run $VIGILANTE_PATH/cmd/main.go bstracker \
+         --config $TESTNET_PATH/vigilante/vigilante.yml
+```
+
 ### Running the vigilante using Docker
 
 #### Running the vigilante reporter in Docker container
@@ -256,6 +274,18 @@ docker run --rm \
          -v $TESTNET_PATH/node0/babylond:/babylon \
          -v $TESTNET_PATH/vigilante:/vigilante \
          babylonchain/vigilante-monitor
+```
+
+#### Running the BTC staking tracker in Docker container
+
+Follow the same steps as above, but with the `babylonchain/btc-staking-tracker` Docker image.
+
+```shell
+docker run --rm \
+         -v $TESTNET_PATH/bitcoin:/bitcoin \
+         -v $TESTNET_PATH/node0/babylond:/babylon \
+         -v $TESTNET_PATH/vigilante:/vigilante \
+         babylonchain/btc-staking-tracker
 ```
 
 #### buildx

--- a/btcstaking-tracker/README.md
+++ b/btcstaking-tracker/README.md
@@ -66,8 +66,6 @@ same height, and
 
 The BTC slasher includes the following subroutines:
 
-<!-- TODO: describe the bootstrap process? -->
-
 - a routine that subscribes to Babylon and forwards all events about finality
   signatures to the `equivocationTracker` routine.
 - `equivocationTracker` routine: Upon an event of a finality signature,
@@ -92,8 +90,9 @@ selective slashing offences by enforcing the *atomic slashing* property: if one
 BTC delegation is slashed, all other BTC delegations under this finality
 provider will be slashed as well. This is achieved by using a cryptographic
 primitive *adaptor signature*.
-<!-- TODO: more technical details -->
 The atomic slasher includes the following routines:
+
+<!-- TODO: more technical details about atomic slashing via adaptor signatures -->
 
 - `btcDelegationTracker` routine: periodically retrieves all BTC delegations and
   saves them to a `BTCDelegationIndex` cache.

--- a/btcstaking-tracker/README.md
+++ b/btcstaking-tracker/README.md
@@ -1,0 +1,3 @@
+# BTC staking tracker
+
+This package implements BTC staking tracker.

--- a/btcstaking-tracker/README.md
+++ b/btcstaking-tracker/README.md
@@ -11,12 +11,21 @@ This package provides the implementation of the BTC staking tracker.
 
 ## Overview
 
-BTC staking tracker is a daemon program that relays information between Babylon and Bitcoin for facilitating the Bitcoin staking protocol.
-This includes three routines:
+BTC staking tracker is a daemon program that relays information between Babylon
+and Bitcoin for facilitating the Bitcoin staking protocol. This includes three
+routines:
 
-- [Unbonding watcher routine](./unbondingwatcher/): upon observing an unbonding transaction of a BTC delegation on Bitcoin, the routine reports the transaction's signature from the staker to Babylon, such that Babylon will unbond the BTC delegation on its side.
-- [BTC slasher](./btcslasher/): upon observing a slashable offence launched by a finality provider, the routine slashes the finality provider and its BTC delegations.
-- [Atomic slasher](./atomicslasher/): upon observing a selective slashing offence where the finality provider maliciously signs and submits a BTC delegation's slashing transaction to Bitcoin, the routine reports the offence to BTC slasher and Babylon.
+- [Unbonding watcher routine](./unbondingwatcher/): upon observing an unbonding
+  transaction of a BTC delegation on Bitcoin, the routine reports the
+  transaction's signature from the staker to Babylon, such that Babylon will
+  unbond the BTC delegation on its side.
+- [BTC slasher](./btcslasher/): upon observing a slashable offence launched by a
+  finality provider, the routine slashes the finality provider and its BTC
+  delegations.
+- [Atomic slasher](./atomicslasher/): upon observing a selective slashing
+  offence where the finality provider maliciously signs and submits a BTC
+  delegation's slashing transaction to Bitcoin, the routine reports the offence
+  to BTC slasher and Babylon.
 
 ## Dependencies
 
@@ -30,20 +39,74 @@ The BTC staking tracker includes the following dependencies:
 
 ### Unbonding watcher routine
 
-The unbonding watcher routine aims to notify Babylon about early unbonding events of BTC delegations.
-It includes the following subroutines:
+The unbonding watcher routine aims to notify Babylon about early unbonding
+events of BTC delegations. It includes the following subroutines:
 
-- `handleNewBlocks` routine: Upon each new BTC block, save its height as the Bitcoin's tip height
-- `fetchDelegations` routine: Periodically, fetch all active BTC delegations from Babylon, and send them to the `handleDelegations` routine.
+- `handleNewBlocks` routine: Upon each new BTC block, save its height as the
+  Bitcoin's tip height
+- `fetchDelegations` routine: Periodically, fetch all active BTC delegations
+  from Babylon, and send them to the `handleDelegations` routine.
 - `handleDelegations` routine:
-  - Upon each new BTC delegation, spawn a new goroutine watching the event that the BTC delegation's unbonding transaction occurs on Bitcoin.
+  - Upon each new BTC delegation, spawn a new goroutine watching the event that
+    the BTC delegation's unbonding transaction occurs on Bitcoin.
   - Upon a BTC delegation is expired, stop tracking the BTC delegation.
-- Upon seeing an unbonding transaction of a BTC delegation on Bitcoin, notify Babylon that the corresponding BTC delegation is unbonded via a `MsgBTCUndelegate` message.
+- Upon seeing an unbonding transaction of a BTC delegation on Bitcoin, notify
+  Babylon that the corresponding BTC delegation is unbonded via a
+  `MsgBTCUndelegate` message.
 
 ### BTC slasher routine
 
-The BTC slasher routine aims to slash adversarial finality providers and their BTC delegations.
-The slashable offences launched by finality providers include 1) *Equivocation* where the finality provider signs two conflicting blocks at the same height, and 2) *Selecive slashing* where the finality provider signs the slashing transaction of a victim BTC delegation and submits it to Bitcoin.
+The BTC slasher routine aims to slash adversarial finality providers and their
+BTC delegations. The slashable offences launched by finality providers include
+
+- *Equivocation* where the finality provider signs two conflicting blocks at the
+same height, and
+- *Selecive slashing* where the finality provider signs the slashing transaction
+  of a victim BTC delegation and submits it to Bitcoin.
+
 The BTC slasher includes the following subroutines:
 
+<!-- TODO: describe the bootstrap process? -->
+
+- a routine that subscribes to Babylon and forwards all events about finality
+  signatures to the `equivocationTracker` routine.
+- `equivocationTracker` routine: Upon an event of a finality signature,
+  1. Check if the event contains an evidence of equivocation.
+  2. If yes, then forward the event to the use the extractable one-time
+     signature's extractability property to extract the equivocating finality
+     provider's secret key.
+  3. Forward the secret key to the `slashingEnforcer` routine.
+- `slashingEnforcer` routine: upon a slashed finality provider's secret key,
+  1. Find all BTC delegations that are active or unbonding under this finality
+     provider
+  2. Try to submit the slashing and unbonding slashing transactions of these BTC
+     delegations to Bitcoin.
+
 ### Atomic slasher routine
+
+The atomic slasher routine aims to slash finality providers that have conducted
+selective slashing offences. In a selective slashing offence, the finality
+provider maliciously signs and submits a BTC delegation's slashing transaction
+to Bitcoin, without affecting other BTC delegations. Babylon circumvents the
+selective slashing offences by enforcing the *atomic slashing* property: if one
+BTC delegation is slashed, all other BTC delegations under this finality
+provider will be slashed as well. This is achieved by using a cryptographic
+primitive *adaptor signature*.
+<!-- TODO: more technical details -->
+The atomic slasher includes the following routines:
+
+- `btcDelegationTracker` routine: periodically retrieves all BTC delegations and
+  saves them to a `BTCDelegationIndex` cache.
+- `slashingTxTracker` routine: upon a BTC block,
+  1. For each transaction, check whether it is a slashing transaction in the
+     `BTCDelegationIndex` cache.
+  2. If a transaction is identified as a slashing transaction, send it to the
+     `selectiveSlashingReporter` routine.
+- `selectiveSlashingReporter` routine: upon a slashing transaction,
+  2. Retrieve the BTC delegation and its finality provider from Babylon.
+  3. If the finality provider is slashed, skip this BTC delegation.
+  4. Try extract the finality provider's secret key by comparing the covenant
+     Schnorr signatures in the slashing transaction and the covenant adaptor
+     signatures.
+  5. If successful, then report the selective slashing offence to Babylon, and
+     forward the extracted secret key to the BTC slasher routine.

--- a/btcstaking-tracker/README.md
+++ b/btcstaking-tracker/README.md
@@ -61,8 +61,8 @@ BTC delegations. The slashable offences launched by finality providers include
 
 - *Equivocation* where the finality provider signs two conflicting blocks at the
 same height, and
-- *Selecive slashing* where the finality provider signs the slashing transaction
-  of a victim BTC delegation and submits it to Bitcoin.
+- *Selective slashing* where the finality provider signs the slashing
+  transaction of a victim BTC delegation and submits it to Bitcoin.
 
 The BTC slasher includes the following subroutines:
 
@@ -89,8 +89,8 @@ to Bitcoin, without affecting other BTC delegations. Babylon circumvents the
 selective slashing offences by enforcing the *atomic slashing* property: if one
 BTC delegation is slashed, all other BTC delegations under this finality
 provider will be slashed as well. This is achieved by using a cryptographic
-primitive *adaptor signature*.
-The atomic slasher includes the following routines:
+primitive called *adaptor signature*. The atomic slasher includes the following
+routines:
 
 <!-- TODO: more technical details about atomic slashing via adaptor signatures -->
 
@@ -104,7 +104,7 @@ The atomic slasher includes the following routines:
 - `selectiveSlashingReporter` routine: upon a slashing transaction,
   2. Retrieve the BTC delegation and its finality provider from Babylon.
   3. If the finality provider is slashed, skip this BTC delegation.
-  4. Try extract the finality provider's secret key by comparing the covenant
+  4. Try to extract the finality provider's secret key by comparing the covenant
      Schnorr signatures in the slashing transaction and the covenant adaptor
      signatures.
   5. If successful, then report the selective slashing offence to Babylon, and

--- a/btcstaking-tracker/README.md
+++ b/btcstaking-tracker/README.md
@@ -3,6 +3,7 @@
 This package provides the implementation of the BTC staking tracker.
 
 - [Overview](#overview)
+- [Dependencies](#dependencies)
 - [Routines](#routines)
   - [Unbonding watcher routine](#unbonding-watcher-routine)
   - [BTC slasher routine](#btc-slasher-routine)
@@ -17,10 +18,32 @@ This includes three routines:
 - [BTC slasher](./btcslasher/): upon observing a slashable offence launched by a finality provider, the routine slashes the finality provider and its BTC delegations.
 - [Atomic slasher](./atomicslasher/): upon observing a selective slashing offence where the finality provider maliciously signs and submits a BTC delegation's slashing transaction to Bitcoin, the routine reports the offence to BTC slasher and Babylon.
 
+## Dependencies
+
+The BTC staking tracker includes the following dependencies:
+
+- A BTC client for querying Bitcoin blocks/transactions.
+- A BTC notifier for getting new events (mainly new BTC blocks) in Bitcoin.
+- A Babylon client for submitting transactions to and querying Babylon.
+
 ## Routines
 
 ### Unbonding watcher routine
 
+The unbonding watcher routine aims to notify Babylon about early unbonding events of BTC delegations.
+It includes the following subroutines:
+
+- `handleNewBlocks` routine: Upon each new BTC block, save its height as the Bitcoin's tip height
+- `fetchDelegations` routine: Periodically, fetch all active BTC delegations from Babylon, and send them to the `handleDelegations` routine.
+- `handleDelegations` routine:
+  - Upon each new BTC delegation, spawn a new goroutine watching the event that the BTC delegation's unbonding transaction occurs on Bitcoin.
+  - Upon a BTC delegation is expired, stop tracking the BTC delegation.
+- Upon seeing an unbonding transaction of a BTC delegation on Bitcoin, notify Babylon that the corresponding BTC delegation is unbonded via a `MsgBTCUndelegate` message.
+
 ### BTC slasher routine
+
+The BTC slasher routine aims to slash adversarial finality providers and their BTC delegations.
+The slashable offences launched by finality providers include 1) *Equivocation* where the finality provider signs two conflicting blocks at the same height, and 2) *Selecive slashing* where the finality provider signs the slashing transaction of a victim BTC delegation and submits it to Bitcoin.
+The BTC slasher includes the following subroutines:
 
 ### Atomic slasher routine

--- a/btcstaking-tracker/README.md
+++ b/btcstaking-tracker/README.md
@@ -1,3 +1,26 @@
 # BTC staking tracker
 
-This package implements BTC staking tracker.
+This package provides the implementation of the BTC staking tracker.
+
+- [Overview](#overview)
+- [Routines](#routines)
+  - [Unbonding watcher routine](#unbonding-watcher-routine)
+  - [BTC slasher routine](#btc-slasher-routine)
+  - [Atomic slasher routine](#atomic-slasher-routine)
+
+## Overview
+
+BTC staking tracker is a daemon program that relays information between Babylon and Bitcoin for facilitating the Bitcoin staking protocol.
+This includes three routines:
+
+- [Unbonding watcher routine](./unbondingwatcher/): upon observing an unbonding transaction of a BTC delegation on Bitcoin, the routine reports the transaction's signature from the staker to Babylon, such that Babylon will unbond the BTC delegation on its side.
+- [BTC slasher](./btcslasher/): upon observing a slashable offence launched by a finality provider, the routine slashes the finality provider and its BTC delegations.
+- [Atomic slasher](./atomicslasher/): upon observing a selective slashing offence where the finality provider maliciously signs and submits a BTC delegation's slashing transaction to Bitcoin, the routine reports the offence to BTC slasher and Babylon.
+
+## Routines
+
+### Unbonding watcher routine
+
+### BTC slasher routine
+
+### Atomic slasher routine

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -1,0 +1,3 @@
+# BTC timestamping monitor
+
+This package implements the BTC timestamping monitor.


### PR DESCRIPTION
Fixes [BM-1026](https://babylon-chain.atlassian.net/browse/BM-1026)

This PR provides the first version of the spec doc for BTC staking tracker. This version is not detailed, mostly aiming for figuring out what will the vigilante doc look like.

After this version, I can think of the following improvements for vigilante docs (in subsequent PRs):

- [ ] Add more references to make the context clear. Currently it assumes the reader has read most of the documents in Babylon side.
- [ ] We need a crispy presentation of the atomic slashing mechanism based on adaptor signatures.
- [ ] Some architecture documents for positioning Bitcoin, vigilantes, Babylon in the entire system.
- [ ] More formal presentations with references to code files.

cc @maurolacy since you are studying BTC staking, maybe you could take a look at this version and see if there are any question. A fresh eye could be very helpful. Thank you!