### PR TITLE
hotfix(monitor): Panic due to a single RPC failure

### DIFF
--- a/cmd/vigilante/cmd/monitor.go
+++ b/cmd/vigilante/cmd/monitor.go
@@ -81,7 +81,7 @@ func GetMonitorCmd() *cobra.Command {
 			monitorMetrics := metrics.NewMonitorMetrics()
 
 			// create monitor
-			vigilanteMonitor, err = monitor.New(&cfg.Monitor, rootLogger, genesisInfo, bbnQueryClient, btcClient, monitorMetrics)
+			vigilanteMonitor, err = monitor.New(&cfg.Monitor, &cfg.Common, rootLogger, genesisInfo, bbnQueryClient, btcClient, monitorMetrics)
 			if err != nil {
 				panic(fmt.Errorf("failed to create vigilante monitor: %w", err))
 			}

--- a/monitor/liveness_checker.go
+++ b/monitor/liveness_checker.go
@@ -57,7 +57,7 @@ func (m *Monitor) CheckLiveness(cr *types.CheckpointRecord) error {
 		err                   error
 	)
 	epoch := cr.EpochNum()
-	endedEpochRes, err := m.BBNQuerier.EndedEpochBTCHeight(cr.EpochNum())
+	endedEpochRes, err := m.queryEndedEpochBTCHeightWithRetry(cr.EpochNum())
 	if err != nil {
 		return fmt.Errorf("the checkpoint at epoch %d is submitted on BTC the epoch is not ended on Babylon: %w", epoch, err)
 	}
@@ -67,13 +67,13 @@ func (m *Monitor) CheckLiveness(cr *types.CheckpointRecord) error {
 	btcHeightFirstSeen = cr.FirstSeenBtcHeight
 	minHeight := minBTCHeight(btcHeightEpochEnded, btcHeightFirstSeen)
 
-	reportedRes, err := m.BBNQuerier.ReportedCheckpointBTCHeight(cr.ID())
+	reportedRes, err := m.queryReportedCheckpointBTCHeightWithRetry(cr.ID())
 	if err != nil {
 		if !errors.Is(err, monitortypes.ErrCheckpointNotReported) {
 			return fmt.Errorf("failed to query checkpoint of epoch %d reported BTC height: %w", epoch, err)
 		}
 		m.logger.Debugf("the checkpoint of epoch %d has not been reported: %s", epoch, err.Error())
-		chainTipRes, err := m.BBNQuerier.BTCHeaderChainTip()
+		chainTipRes, err := m.queryBTCHeaderChainTipWithRetry()
 		if err != nil {
 			return fmt.Errorf("failed to query the current tip height of BTC light client: %w", err)
 		}

--- a/monitor/liveness_checker_test.go
+++ b/monitor/liveness_checker_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func FuzzLivenessChecker(f *testing.F) {
-	bbndatagen.AddRandomSeedsToFuzzer(f, 100)
+	bbndatagen.AddRandomSeedsToFuzzer(f, 10)
 
 	f.Fuzz(func(t *testing.T, seed int64) {
 		r := rand.New(rand.NewSource(seed))
@@ -28,7 +28,12 @@ func FuzzLivenessChecker(f *testing.F) {
 		maxGap := bbndatagen.RandomIntOtherThan(r, 0, 50) + 200
 		cfg := &config.MonitorConfig{MaxLiveBtcHeights: maxGap}
 		m := &monitor.Monitor{
-			Cfg:        cfg,
+			Cfg: cfg,
+			// to disable the retry
+			ComCfg: &config.CommonConfig{
+				RetrySleepTime:    1,
+				MaxRetrySleepTime: 0,
+			},
 			BBNQuerier: mockBabylonClient,
 		}
 		logger, err := config.NewRootLogger("auto", "debug")

--- a/monitor/monitor_test.go
+++ b/monitor/monitor_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/babylonchain/babylon/crypto/bls12381"
 	"github.com/babylonchain/babylon/testutil/datagen"
 	ckpttypes "github.com/babylonchain/babylon/x/checkpointing/types"
-	"github.com/babylonchain/vigilante/monitor"
-	"github.com/babylonchain/vigilante/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/golang/mock/gomock"
 	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/require"
+
+	"github.com/babylonchain/vigilante/config"
+	"github.com/babylonchain/vigilante/monitor"
+	"github.com/babylonchain/vigilante/types"
 )
 
 func GetMsgBytes(epoch uint64, hash *ckpttypes.BlockHash) []byte {
@@ -35,6 +37,11 @@ func FuzzVerifyCheckpoint(f *testing.F) {
 		ctl := gomock.NewController(t)
 		mockBabylonClient := monitor.NewMockBabylonQueryClient(ctl)
 		m := &monitor.Monitor{
+			// to disable the retry
+			ComCfg: &config.CommonConfig{
+				RetrySleepTime:    1,
+				MaxRetrySleepTime: 0,
+			},
 			BBNQuerier: mockBabylonClient,
 		}
 

--- a/monitor/query.go
+++ b/monitor/query.go
@@ -3,7 +3,13 @@ package monitor
 import (
 	"fmt"
 
+	"github.com/babylonchain/babylon/types/retry"
+	btclctypes "github.com/babylonchain/babylon/x/btclightclient/types"
 	ckpttypes "github.com/babylonchain/babylon/x/checkpointing/types"
+	epochingtypes "github.com/babylonchain/babylon/x/epoching/types"
+	monitortypes "github.com/babylonchain/babylon/x/monitor/types"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"go.uber.org/zap"
 
 	"github.com/babylonchain/vigilante/types"
 )
@@ -11,7 +17,7 @@ import (
 // QueryInfoForNextEpoch fetches necessary information for verifying the next epoch from Babylon
 func (m *Monitor) QueryInfoForNextEpoch(epoch uint64) (*types.EpochInfo, error) {
 	// query validator set with BLS
-	res, err := m.BBNQuerier.BlsPublicKeyList(epoch, nil)
+	res, err := m.queryBlsPublicKeyListWithRetry(epoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query BLS key set for epoch %v: %w", epoch, err)
 	}
@@ -32,14 +38,14 @@ func (m *Monitor) QueryInfoForNextEpoch(epoch uint64) (*types.EpochInfo, error) 
 
 // FindTipConfirmedEpoch tries to find the last confirmed epoch number from Babylon
 func (m *Monitor) FindTipConfirmedEpoch() (uint64, error) {
-	epochRes, err := m.BBNQuerier.CurrentEpoch()
+	epochRes, err := m.queryCurrentEpochWithRetry()
 	if err != nil {
 		return 0, fmt.Errorf("failed to query the current epoch of Babylon: %w", err)
 	}
 	curEpoch := epochRes.CurrentEpoch
 	m.logger.Debugf("current epoch number is %v", curEpoch)
 	for curEpoch >= 1 {
-		ckptRes, err := m.BBNQuerier.RawCheckpoint(curEpoch - 1)
+		ckptRes, err := m.queryRawCheckpointWithRetry(curEpoch - 1)
 		if err != nil {
 			return 0, fmt.Errorf("failed to query the checkpoint of epoch %v: %w", curEpoch-1, err)
 		}
@@ -50,4 +56,151 @@ func (m *Monitor) FindTipConfirmedEpoch() (uint64, error) {
 	}
 
 	return 0, fmt.Errorf("cannot find a confirmed or finalized epoch from Babylon")
+}
+
+func (m *Monitor) queryCurrentEpochWithRetry() (*epochingtypes.QueryCurrentEpochResponse, error) {
+	var currentEpochRes epochingtypes.QueryCurrentEpochResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.CurrentEpoch()
+		if err != nil {
+			return err
+		}
+
+		currentEpochRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the current epoch", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &currentEpochRes, nil
+}
+
+func (m *Monitor) queryRawCheckpointWithRetry(epoch uint64) (*ckpttypes.QueryRawCheckpointResponse, error) {
+	var rawCheckpointRes ckpttypes.QueryRawCheckpointResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.RawCheckpoint(epoch)
+		if err != nil {
+			return err
+		}
+
+		rawCheckpointRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the raw checkpoint", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &rawCheckpointRes, nil
+}
+
+func (m *Monitor) queryBlsPublicKeyListWithRetry(epoch uint64) (*ckpttypes.QueryBlsPublicKeyListResponse, error) {
+	var blsPublicKeyListRes ckpttypes.QueryBlsPublicKeyListResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.BlsPublicKeyList(epoch, nil)
+		if err != nil {
+			return err
+		}
+
+		blsPublicKeyListRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the BLS public key list", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &blsPublicKeyListRes, nil
+}
+
+func (m *Monitor) queryEndedEpochBTCHeightWithRetry(epoch uint64) (*monitortypes.QueryEndedEpochBtcHeightResponse, error) {
+	var endedEpochBTCHeightRes monitortypes.QueryEndedEpochBtcHeightResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.EndedEpochBTCHeight(epoch)
+		if err != nil {
+			return err
+		}
+
+		endedEpochBTCHeightRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the ended epoch BTC height", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &endedEpochBTCHeightRes, nil
+}
+
+func (m *Monitor) queryReportedCheckpointBTCHeightWithRetry(hashStr string) (*monitortypes.QueryReportedCheckpointBtcHeightResponse, error) {
+	var reportedCheckpointBtcHeightRes monitortypes.QueryReportedCheckpointBtcHeightResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.ReportedCheckpointBTCHeight(hashStr)
+		if err != nil {
+			return err
+		}
+
+		reportedCheckpointBtcHeightRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the reported checkpoint BTC height", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &reportedCheckpointBtcHeightRes, nil
+}
+
+func (m *Monitor) queryBTCHeaderChainTipWithRetry() (*btclctypes.QueryTipResponse, error) {
+	var btcHeaderChainTipRes btclctypes.QueryTipResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.BTCHeaderChainTip()
+		if err != nil {
+			return err
+		}
+
+		btcHeaderChainTipRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the BTC header chain tip", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &btcHeaderChainTipRes, nil
+}
+
+func (m *Monitor) queryContainsBTCBlockWithRetry(blockHash *chainhash.Hash) (*btclctypes.QueryContainsBytesResponse, error) {
+	var containsBTCBlockRes btclctypes.QueryContainsBytesResponse
+
+	if err := retry.Do(m.ComCfg.RetrySleepTime, m.ComCfg.MaxRetrySleepTime, func() error {
+		res, err := m.BBNQuerier.ContainsBTCBlock(blockHash)
+		if err != nil {
+			return err
+		}
+
+		containsBTCBlockRes = *res
+		return nil
+	}); err != nil {
+		m.logger.Debug(
+			"failed to query the contains BTC block", zap.Error(err))
+
+		return nil, err
+	}
+
+	return &containsBTCBlockRes, nil
 }

--- a/monitor/query_test.go
+++ b/monitor/query_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/babylonchain/vigilante/config"
 	"github.com/babylonchain/vigilante/monitor"
 	"github.com/babylonchain/vigilante/types"
 )
@@ -40,6 +41,11 @@ func FuzzQueryInfoForNextEpoch(f *testing.F) {
 		).AnyTimes()
 		expectedEI := types.NewEpochInfo(e, *valSet)
 		m := &monitor.Monitor{
+			// to disable the retry
+			ComCfg: &config.CommonConfig{
+				RetrySleepTime:    1,
+				MaxRetrySleepTime: 0,
+			},
 			BBNQuerier: bbnCli,
 		}
 		ei, err := m.QueryInfoForNextEpoch(e)


### PR DESCRIPTION
This PR fixed the issue that the monitor panics due to a single rpc failure by adding retry to all the rpc calls to bitcoind.

Future improvement can be done by reducing unnecessary RPC calls #218 and persisting the last processed height and epoch number #219